### PR TITLE
add GitHub sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://www.paypal.com/donate/?hosted_button_id=JVNQGYXCQ2GPG


### PR DESCRIPTION
## Purpose

Enable a "Sponsor" button on this Repository

## Implementation

Use the PayPal link from the repo's README.md

## Testing

The sponsor button resulting from this PR can be previewed: https://github.com/david-allison/fxsound-app

<details>

<summary>Screenshots</summary>

----

**Screenshot: Top bar**

![Screenshot 2023-11-30 at 21 14 42](https://github.com/fxsound2/fxsound-app/assets/62114487/4caa08c0-4ef1-48bb-9a67-3ff6eec11f1c)

----

**Screenshot: On Click**

![Screenshot 2023-11-30 at 21 14 49](https://github.com/fxsound2/fxsound-app/assets/62114487/adc581db-ab54-43ba-997e-3fec37c9e493)

</details>

## Additional Steps

❗ The following setting must be set on this repository for this change to take effect:

* [Settings - Features - Sponsorships](https://github.com/fxsound2/fxsound-app/settings#features)

## Learning

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

Optional reading: The docs give a list of alternate platforms for donations

----

PS: Congrats on open-sourcing 👍