### PR TITLE
allow more than 10 presets

### DIFF
--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -681,12 +681,6 @@ void FxController::savePreset(const String& preset_name)
 		setPreset(selected_preset);
 
 		model.pushMessage(FormatString(TRANS("New preset %s is saved."), preset_name));
-
-		if (model.getUserPresetCount() == 10)
-		{
-			Thread::sleep(2000);
-			model.pushMessage(TRANS("Reached the limit on new presets."));
-		}
 	}
 
 	model.setPresetModified(false);

--- a/fxsound/Source/GUI/FxMainWindow.cpp
+++ b/fxsound/Source/GUI/FxMainWindow.cpp
@@ -377,7 +377,7 @@ void FxMainWindow::showMenu()
 	}
 
 	auto power_state = model.getPowerState();
-	popup_menu.addSubMenu(TRANS("Save New Preset"), save_menu, model.isPresetModified() && model.getUserPresetCount() < 10 && power_state);
+	popup_menu.addSubMenu(TRANS("Save New Preset"), save_menu, model.isPresetModified() && power_state);
 	popup_menu.addItem(overwrite_menu_name, model.isPresetModified() && user_preset && power_state, false, overwriteClicked);
 	popup_menu.addItem(TRANS("Undo Preset Changes"), model.isPresetModified() && power_state, false, undoClicked);
 	popup_menu.addSubMenu(TRANS("Rename Preset"), rename_menu, !model.isPresetModified() && user_preset && power_state);


### PR DESCRIPTION
Removes the limit of 10 presets.
Resolves https://github.com/fxsound2/fxsound-app/issues/5
Although I'm not sure why the limit was there in the first place. The dialog works just fine with 20+ presets. 
See: https://github.com/fxsound2/fxsound-app/issues/5#issuecomment-1837834819 