### PR TITLE
feat: toggleable autostart.

### DIFF
--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -1554,6 +1554,37 @@ void FxController::setOutputAutoSelect(bool auto_select)
     settings_.setBool("disable_auto_switch_output", !auto_select);
 }
 
+bool FxController::isLaunchOnStartup()
+{
+	HKEY hkey;
+	RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_QUERY_VALUE, &hkey);
+	DWORD type;
+	DWORD size = 0;
+	RegQueryValueEx(hkey, L"FxSound", NULL, &type, NULL, &size);
+	RegCloseKey(hkey);
+
+	return size > 0;
+}
+
+void FxController::setLaunchOnStartup(bool launch_on_startup)
+{
+	wchar_t szPath[MAX_PATH];
+	GetModuleFileName(NULL, szPath, MAX_PATH);
+	HKEY hkey;
+	RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_SET_VALUE, &hkey);
+
+	if (launch_on_startup)
+	{
+		RegSetValueEx(hkey, L"FxSound", 0, REG_SZ, (BYTE*)szPath, sizeof(szPath));
+	}
+	else
+	{
+		RegDeleteValue(hkey, L"FxSound");
+	}
+
+	RegCloseKey(hkey);
+}
+
 void FxController::registerHotkeys()
 {
 	if (!hotkeys_registered_)

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -98,6 +98,9 @@ public:
     bool isOutputAutoSelect();
     void setOutputAutoSelect(bool auto_select);
 
+	bool isLaunchOnStartup();
+	void setLaunchOnStartup(bool launch_on_startup);
+
     bool isHelpTooltipsHidden();
     void setHelpTooltipsHidden(bool status);
 

--- a/fxsound/Source/GUI/FxSettingsDialog.cpp
+++ b/fxsound/Source/GUI/FxSettingsDialog.cpp
@@ -180,6 +180,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	launch_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
 	launch_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	launch_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+	launch_toggle_.setWantsKeyboardFocus(true);
     auto_select_output_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
     auto_select_output_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
     auto_select_output_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
@@ -223,6 +224,9 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 											}
 										};
 
+	launch_toggle_.setToggleState(FxController::getInstance().isLaunchOnStartup(), NotificationType::dontSendNotification);
+	launch_toggle_.onClick = [this]() { FxController::getInstance().setLaunchOnStartup(launch_toggle_.getToggleState()); };
+
     auto_select_output_toggle_.setToggleState(FxController::getInstance().isOutputAutoSelect(), NotificationType::dontSendNotification);
     auto_select_output_toggle_.onClick = [this]() { FxController::getInstance().setOutputAutoSelect(auto_select_output_toggle_.getToggleState()); };
 
@@ -237,7 +241,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 		reset_presets_button_.setEnabled(false);
 	};
 
-	addChildComponent(&launch_toggle_);
+	addAndMakeVisible(&launch_toggle_);
     addAndMakeVisible(&auto_select_output_toggle_);
     addAndMakeVisible(&hide_help_tips_toggle_);
 	addAndMakeVisible(&hotkeys_toggle_);
@@ -256,13 +260,15 @@ void FxSettingsDialog::GeneralSettingsPane::resized()
     language_switch_.setBounds(X_MARGIN, LANGUAGE_SWITCH_Y, FxLanguage::WIDTH, FxLanguage::HEIGHT);
 
     int y = language_switch_.getBottom() + 20;
-    auto_select_output_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
+	launch_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
+
+	y = launch_toggle_.getBottom() + 20;
+	auto_select_output_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
     y = auto_select_output_toggle_.getBottom() + 10;
     hide_help_tips_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
     y = hide_help_tips_toggle_.getBottom() + 10;
-
 	hotkeys_toggle_.setBounds(X_MARGIN, y, getWidth()-X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
 	y = hotkeys_toggle_.getBottom() + 5;


### PR DESCRIPTION
 resolves #18 
Tested on Windows 10 & 11. Should work on all versions >Win95 though.

---

Additional question for maintainers: Before working on the next issues, can I do a chore PR that consistently switches everything to tabs? Because currently there are spaces mixed in some places (while the majority is tab) which makes VisualStudio switch to "mixed mode". I'd also clean out obsolete / unused stuff like https://github.com/fxsound2/fxsound-app/blob/main/fxsound/Source/GUI/FxSettingsDialog.cpp#L345-L346 in the process

edit: apparently some files are spaces-only, some are mixed and some are tabs only. 
Which one is preferred?

along the conversion and stuff I'd probably add some auto linting as well (based on the current code style) 
with a github action as well perhaps? 