### PR TITLE
Fix for: Conflict(s) between certain key combinations/symbols and FxS…

### DIFF
--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -1315,39 +1315,85 @@ bool FxController::setHotkey(const String& command, int new_mod, int new_vk)
 	if (command == HK_CMD_ON_OFF)
 	{
 		::UnregisterHotKey(message_window_.getHandle(), CMD_ON_OFF);
-		::RegisterHotKey(message_window_.getHandle(), CMD_ON_OFF, new_mod, new_vk);
+		if (isValidHotkey(new_mod, new_vk))
+		{
+			::RegisterHotKey(message_window_.getHandle(), CMD_ON_OFF, new_mod, new_vk);
+		}		
 		return true;
 	}
 
 	if (command == HK_CMD_OPEN_CLOSE)
 	{
 		::UnregisterHotKey(message_window_.getHandle(), CMD_OPEN_CLOSE);
-		::RegisterHotKey(message_window_.getHandle(), CMD_OPEN_CLOSE, new_mod, new_vk);
+		if (isValidHotkey(new_mod, new_vk))
+		{
+			::RegisterHotKey(message_window_.getHandle(), CMD_OPEN_CLOSE, new_mod, new_vk);
+		}		
 		return true;
 	}
 
 	if (command == HK_CMD_NEXT_PRESET)
 	{
 		::UnregisterHotKey(message_window_.getHandle(), CMD_NEXT_PRESET);
-		::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_PRESET, new_mod, new_vk);
+		if (isValidHotkey(new_mod, new_vk))
+		{
+			::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_PRESET, new_mod, new_vk);
+		}		
 		return true;
 	}
 
 	if (command == HK_CMD_PREVIOUS_PRESET)
 	{
 		::UnregisterHotKey(message_window_.getHandle(), CMD_PREVIOUS_PRESET);
-		::RegisterHotKey(message_window_.getHandle(), CMD_PREVIOUS_PRESET, new_mod, new_vk);
+		if (isValidHotkey(new_mod, new_vk))
+		{
+			::RegisterHotKey(message_window_.getHandle(), CMD_PREVIOUS_PRESET, new_mod, new_vk);
+		}		
 		return true;
 	}
 
 	if (command == HK_CMD_NEXT_OUTPUT)
 	{
 		::UnregisterHotKey(message_window_.getHandle(), CMD_NEXT_OUTPUT);
-		::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_OUTPUT, new_mod, new_vk);
+		if (isValidHotkey(new_mod, new_vk))
+		{
+			::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_OUTPUT, new_mod, new_vk);
+		}		
 		return true;
 	}
 
 	return false;
+}
+
+bool FxController::isValidHotkey(int mod, int vk)
+{
+	if ((mod & MOD_CONTROL) == 0)
+	{
+		return false;
+	}
+		
+	HKL hkl = GetKeyboardLayout(0);
+	BYTE kbd_state[256] = { 0 };
+	kbd_state[VK_CONTROL] = 0x80;
+
+	if ((mod & MOD_ALT) != 0)
+	{
+		kbd_state[VK_MENU] = 0x80;
+	}
+	if ((mod & MOD_SHIFT) != 0)
+	{
+		kbd_state[VK_SHIFT] = 0x80;
+	}
+	
+	WCHAR output[3] = { 0 };
+
+	int len = ToUnicodeEx(vk, 0, kbd_state, output, 3, 0, hkl);
+	if (len > 0 && output[0] >= 0x20) // The hotkey combination generates a non-control character
+	{
+		return false;
+	}
+
+	return true;
 }
 
 bool FxController::isHelpTooltipsHidden()
@@ -1563,27 +1609,45 @@ void FxController::registerHotkeys()
 
 		if (getHotkey(HK_CMD_ON_OFF, mod, vk))
 		{
-			::RegisterHotKey(message_window_.getHandle(), CMD_ON_OFF, mod, vk);
+			if (isValidHotkey(mod, vk))
+			{
+				::RegisterHotKey(message_window_.getHandle(), CMD_ON_OFF, mod, vk);
+			}			
 		}
 		
 		if (getHotkey(HK_CMD_OPEN_CLOSE, mod, vk))
 		{
-			::RegisterHotKey(message_window_.getHandle(), CMD_OPEN_CLOSE, mod, vk);
+			if (isValidHotkey(mod, vk))
+			{
+				::RegisterHotKey(message_window_.getHandle(), CMD_OPEN_CLOSE, mod, vk);
+			}
+			
 		}
 
 		if (getHotkey(HK_CMD_NEXT_PRESET, mod, vk))
 		{
-			::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_PRESET, mod, vk);
+			if (isValidHotkey(mod, vk))
+			{
+				::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_PRESET, mod, vk);
+			}
+			
 		}
 
 		if (getHotkey(HK_CMD_PREVIOUS_PRESET, mod, vk))
 		{
-			::RegisterHotKey(message_window_.getHandle(), CMD_PREVIOUS_PRESET, mod, vk);
+			if (isValidHotkey(mod, vk))
+			{
+				::RegisterHotKey(message_window_.getHandle(), CMD_PREVIOUS_PRESET, mod, vk);
+			}
+			
 		}
 
 		if (getHotkey(HK_CMD_NEXT_OUTPUT, mod, vk))
 		{
-			::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_OUTPUT, mod, vk);
+			if (isValidHotkey(mod, vk))
+			{
+				::RegisterHotKey(message_window_.getHandle(), CMD_NEXT_OUTPUT, mod, vk);
+			}			
 		}
 		
 		hotkeys_registered_ = true;

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -93,7 +93,8 @@ public:
 
 	void enableHotkeys(bool enable);
 	bool getHotkey(String cmdKey, int& mod, int& vk);
-	bool setHotkey(const String& command, int new_mod, int new_vk);
+	bool setHotkey(const String& command, int new_mod, int vk);
+	bool isValidHotkey(int mod, int new_vk);
 
     bool isOutputAutoSelect();
     void setOutputAutoSelect(bool auto_select);

--- a/fxsound/Source/GUI/FxHotkeyLabel.cpp
+++ b/fxsound/Source/GUI/FxHotkeyLabel.cpp
@@ -92,6 +92,45 @@ bool FxHotkeyEditor::keyPressed(const KeyPress& key)
 		vk = static_cast<int>(keyCode);
 	}
 
+	int saved_mod;
+	int saved_vk;
+	auto& controller = FxController::getInstance();
+	if (controller.getHotkey(FxController::HK_CMD_ON_OFF, saved_mod, saved_vk))
+	{
+		if (mod == saved_mod && vk == saved_vk)
+		{
+			return false;
+		}
+	}
+	if (controller.getHotkey(FxController::HK_CMD_OPEN_CLOSE, saved_mod, saved_vk))
+	{
+		if (mod == saved_mod && vk == saved_vk)
+		{
+			return false;
+		}
+	}
+	if (controller.getHotkey(FxController::HK_CMD_NEXT_PRESET, saved_mod, saved_vk))
+	{
+		if (mod == saved_mod && vk == saved_vk)
+		{
+			return false;
+		}
+	}
+	if (controller.getHotkey(FxController::HK_CMD_PREVIOUS_PRESET, saved_mod, saved_vk))
+	{
+		if (mod == saved_mod && vk == saved_vk)
+		{
+			return false;
+		}
+	}
+	if (controller.getHotkey(FxController::HK_CMD_NEXT_OUTPUT, saved_mod, saved_vk))
+	{
+		if (mod == saved_mod && vk == saved_vk)
+		{
+			return false;
+		}
+	}
+
 	if (vk != 0)
 	{
 		mod_ = mod;
@@ -138,7 +177,14 @@ void FxHotkeyEditor::paint(juce::Graphics& g)
 	auto& theme = dynamic_cast<FxTheme&>(getLookAndFeel());
 	if (isEnabled())
 	{
-		setColour(Label::textColourId, theme.findColour(TextButton::buttonColourId));
+		if (FxController::getInstance().isValidHotkey(mod_, vk_))
+		{
+			setColour(Label::textColourId, theme.findColour(TextButton::buttonColourId));
+		}
+		else
+		{
+			setColour(Label::textColourId, theme.findColour(TextEditor::textColourId));
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Fixed the hotkey conflict by avoiding RegisterHotkey call for the hotkey combinations which result in a valid character when calling  ToUnicodeEx