### PR TITLE
Fix a Y2038 bug by replacing Int32x32To64 with multiplication

### DIFF
--- a/audiopassthru/src/ptime/Ptime.cpp
+++ b/audiopassthru/src/ptime/Ptime.cpp
@@ -403,7 +403,7 @@ int PT_DECLSPEC ptimeUnixTimeToFileTime(time_t t, LPFILETIME pft)
      // Note that LONGLONG is a 64-bit value
      LONGLONG ll;
 
-     ll = Int32x32To64(t, 10000000) + 116444736000000000;
+     ll = (t * 10000000LL) + 116444736000000000LL;
      pft->dwLowDateTime = (DWORD)ll;
      pft->dwHighDateTime = (DWORD)(ll >> 32);
 


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>