### PR TITLE
Feature "prefer custom notifications" setting

### DIFF
--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -168,6 +168,7 @@ FxController::FxController() : message_window_(L"FxSoundHotkeys", (WNDPROC) even
 
     free_plan_ = settings_.getBool("free_plan");
     hide_help_tooltips_ = settings_.getBool("hide_help_tooltips");
+    prefer_custom_notifications_ = settings_.getBool("prefer_custom_notifications");
     output_device_id_ = settings_.getString("output_device_id");
     output_device_name_ = settings_.getString("output_device_name");
 	max_user_presets_ = settings_.getInt("max_user_presets");
@@ -1515,6 +1516,18 @@ void FxController::setHelpTooltipsHidden(bool status)
 {
     hide_help_tooltips_ = status;
     settings_.setBool("hide_help_tooltips", status);
+    main_window_->repaint();
+}
+
+bool FxController::isCustomNotificationsPreferred()
+{
+    return prefer_custom_notifications_;
+}
+
+void FxController::setCustomNotificationsPreferred(bool status)
+{
+    prefer_custom_notifications_ = status;
+    settings_.setBool("prefer_custom_notifications", status);
     main_window_->repaint();
 }
 

--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -643,6 +643,12 @@ void FxController::setOutput(int output, bool notify)
 			dfx_dsp_.powerOn(true);
 			audio_passthru_->mute(false);
         }
+
+        FxModel::getModel().pushMessage(TRANS("Output: ") + output_device_name_);
+        if (mono_device)
+        {
+            FxModel::getModel().pushMessage(TRANS("FxSound does not support mono devices, so FxSound processing had been disabled for this device."));
+        }
     }
 
 	FxModel::getModel().setSelectedOutput(output, selected_sound_device, notify);

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -108,6 +108,9 @@ public:
     bool isHelpTooltipsHidden();
     void setHelpTooltipsHidden(bool status);
 
+    bool isCustomNotificationsPreferred();
+    void setCustomNotificationsPreferred(bool status);
+
     String getLanguage() const;
     void setLanguage(String language_code);
     String getLanguageName(String language_code) const;
@@ -204,7 +207,8 @@ private:
     StringArray output_ids_;
 	std::vector<SoundDevice> output_devices_;
     bool hide_help_tooltips_;
-    
+    bool prefer_custom_notifications_;
+
 	unsigned long audio_process_time_;
 	int audio_process_on_counter_;
 	int audio_process_off_counter_;

--- a/fxsound/Source/GUI/FxSettingsDialog.cpp
+++ b/fxsound/Source/GUI/FxSettingsDialog.cpp
@@ -176,6 +176,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
     SettingsPane("General Preferences"),
     launch_toggle_(TRANS("Launch on system startup")),
     hide_help_tips_toggle_(TRANS("Hide help tips for audio controls")),
+    prefer_custom_notifications_toggle_(TRANS("Prefer FxSound custom notifications")),
 	hotkeys_toggle_(TRANS("Disable keyboard shortcuts")),
 	reset_presets_button_(TRANS("Reset presets to factory defaults"))
 {
@@ -222,6 +223,10 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
     hide_help_tips_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
     hide_help_tips_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hide_help_tips_toggle_.setWantsKeyboardFocus(true);
+    prefer_custom_notifications_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
+    prefer_custom_notifications_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+    prefer_custom_notifications_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+    prefer_custom_notifications_toggle_.setWantsKeyboardFocus(true);
 	hotkeys_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
 	hotkeys_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hotkeys_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
@@ -259,7 +264,10 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 
     hide_help_tips_toggle_.setToggleState(FxController::getInstance().isHelpTooltipsHidden(), NotificationType::dontSendNotification);
     hide_help_tips_toggle_.onClick = [this]() { FxController::getInstance().setHelpTooltipsHidden(hide_help_tips_toggle_.getToggleState()); };
-	
+
+    prefer_custom_notifications_toggle_.setToggleState(FxController::getInstance().isCustomNotificationsPreferred(), NotificationType::dontSendNotification);
+    prefer_custom_notifications_toggle_.onClick = [this]() { FxController::getInstance().setCustomNotificationsPreferred(prefer_custom_notifications_toggle_.getToggleState()); };
+
 	reset_presets_button_.setSize(BUTTON_WIDTH, BUTTON_HEIGHT);
 	reset_presets_button_.setEnabled(FxModel::getModel().getUserPresetCount() > 0);
     reset_presets_button_.setMouseCursor(MouseCursor::PointingHandCursor);
@@ -277,6 +285,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	addAndMakeVisible(&endpoint_title_);
 	addAndMakeVisible(&preferred_endpoint_);
 	addAndMakeVisible(&hide_help_tips_toggle_);
+    addAndMakeVisible(&prefer_custom_notifications_toggle_);
 	addAndMakeVisible(&hotkeys_toggle_);
 	addAndMakeVisible(&reset_presets_button_);
 	addAndMakeVisible(&language_switch_);
@@ -312,7 +321,10 @@ void FxSettingsDialog::GeneralSettingsPane::resized()
 	y = preferred_endpoint_.getBottom() + 20;
     hide_help_tips_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
-    y = hide_help_tips_toggle_.getBottom() + 10;
+	y = hide_help_tips_toggle_.getBottom() + 10;
+    prefer_custom_notifications_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
+
+    y = prefer_custom_notifications_toggle_.getBottom() + 10;
 	hotkeys_toggle_.setBounds(X_MARGIN, y, getWidth()-X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
 	y = hotkeys_toggle_.getBottom() + 5;
@@ -341,6 +353,7 @@ void FxSettingsDialog::GeneralSettingsPane::setText()
     int height = FxSettingsDialog::SettingsComponent::HEIGHT;
     launch_toggle_.setButtonText(TRANS("Launch on system startup"));
     hide_help_tips_toggle_.setButtonText(TRANS("Hide help tips for audio controls"));
+    prefer_custom_notifications_toggle_.setButtonText(TRANS("Prefer FxSound custom notifications"));
     hotkeys_toggle_.setButtonText(TRANS("Disable keyboard shortcuts"));
     reset_presets_button_.setButtonText(TRANS("Reset presets to factory defaults"));
 	endpoint_title_.setText(TRANS("Preferred output:"), NotificationType::dontSendNotification);

--- a/fxsound/Source/GUI/FxSettingsDialog.h
+++ b/fxsound/Source/GUI/FxSettingsDialog.h
@@ -114,6 +114,7 @@ private:
 
         ToggleButton launch_toggle_;
         ToggleButton hide_help_tips_toggle_;
+        ToggleButton prefer_custom_notifications_toggle_;
 		ToggleButton hotkeys_toggle_;
 		TextButton reset_presets_button_;
 		OwnedArray<FxHotkeyLabel> hotkey_labels_;

--- a/fxsound/Source/GUI/FxSystemTrayView.cpp
+++ b/fxsound/Source/GUI/FxSystemTrayView.cpp
@@ -32,11 +32,11 @@ FxSystemTrayView::FxSystemTrayView()
         os == SystemStats::OperatingSystemType::Windows8_0 ||
         os == SystemStats::OperatingSystemType::Windows8_1)
     {
-        custom_notification_ = true;
+        system_notifications_available_ = false;
     }
     else
     {
-        custom_notification_ = false;
+        system_notifications_available_ = true;
     }
 
     addToDesktop(0);
@@ -259,7 +259,12 @@ void FxSystemTrayView::showNotification()
 
     if (message.isNotEmpty())
     {
-        if (custom_notification_ || link.first.isNotEmpty())
+        bool use_custom_notification =
+            !system_notifications_available_
+            || link.first.isNotEmpty()
+            || FxController::getInstance().isCustomNotificationsPreferred();
+
+        if (use_custom_notification)
         {
             NOTIFYICONIDENTIFIER icon_id = {};
             RECT rect;

--- a/fxsound/Source/GUI/FxSystemTrayView.h
+++ b/fxsound/Source/GUI/FxSystemTrayView.h
@@ -54,7 +54,7 @@ private:
 	void showContextMenu();
 	void showNotification();	
 
-	bool custom_notification_;
+	bool system_notifications_available_;
 	FxNotification notification_;
 	WNDPROC componentWndProc_;
 


### PR DESCRIPTION
Gives user an option to use custom FxSound notification instead of Windows notifications (https://github.com/fxsound2/fxsound-app/issues/188).

Fixes a bug with no notification on output device change (https://github.com/fxsound2/fxsound-app/issues/243)

@bvijay74 hi! Please review this PR