### PR TITLE
feat: allow device specific presets

### DIFF
--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -188,17 +188,6 @@ FxController::FxController() : message_window_(L"FxSoundHotkeys", (WNDPROC) even
 
 	device_specific_preset_ = settings_.getBool("device_specific_preset");
 
-	DynamicObject* obj = new DynamicObject();
-	obj->setProperty("foo", "bar");
-	obj->setProperty("num", 123);
-
-	DynamicObject* nestedObj = new DynamicObject();
-	nestedObj->setProperty("inner", "value");
-	obj->setProperty("nested", nestedObj);
-
-	var json(obj); // store the outer object in a var [we could have done this earlier]
-	String s = JSON::toString(json);
-
 	String loaded_settings_string = settings_.getString("device_preset_map_");
 
 	auto parsed_device_preset_map = JSON::parse(loaded_settings_string);

--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -188,14 +188,14 @@ FxController::FxController() : message_window_(L"FxSoundHotkeys", (WNDPROC) even
 
 	device_specific_preset_ = settings_.getBool("device_specific_preset");
 
-	String loaded_settings_string = settings_.getString("device_preset_map_");
+	String loaded_settings_string = settings_.getString("device_preset_map");
 
 	auto parsed_device_preset_map = JSON::parse(loaded_settings_string);
 	String ad = JSON::toString(parsed_device_preset_map);
 
 	device_preset_map_ = parsed_device_preset_map.getDynamicObject()
-		? DynamicObject(*parsed_device_preset_map.getDynamicObject()->clone().get())
-		: DynamicObject();
+		? parsed_device_preset_map.getDynamicObject()
+		: new juce::DynamicObject();
 
 
     output_device_id_ = settings_.getString("output_device_id");
@@ -359,17 +359,17 @@ void FxController::init(FxMainWindow* main_window, FxSystemTrayView* system_tray
 		bool device_specific_preset = settings_.getBool("device_specific_preset");
 		if (device_specific_preset)
 		{
-			String loaded_settings_string = settings_.getString("device_preset_map_");
+			String loaded_settings_string = settings_.getString("device_preset_map");
 
-			auto parsed_device_preset_map = JSON::fromString(settings_.getString("device_preset_map_"));
+			auto parsed_device_preset_map = JSON::fromString(settings_.getString("device_preset_map"));
 
-			device_preset_map_ = parsed_device_preset_map.getDynamicObject() != nullptr
-				? DynamicObject(*parsed_device_preset_map.getDynamicObject()->clone().get())
-				: DynamicObject();
 
-			if (device_preset_map_.hasProperty(output_device_id_))
+			auto* obj = parsed_device_preset_map.getDynamicObject();
+			device_preset_map_ = obj ? obj : new juce::DynamicObject();
+
+			if (device_preset_map_->hasProperty(output_device_id_))
 			{
-				preset_name = device_preset_map_.getProperty(output_device_id_);
+				preset_name = device_preset_map_->getProperty(output_device_id_);
 			}
 		}
 
@@ -1674,21 +1674,24 @@ void FxController::setDeviceSpecificPreset(bool status)
 
 String FxController::getDevicePreset(const String& device_id)
 {
-	return device_preset_map_.getProperty(device_id);
+	return device_preset_map_->getProperty(device_id);
 }
 
 void FxController::setDevicePreset(const String& device_id, const String& preset_id)
 {
 	if (device_id == "")
 		return;
-	device_preset_map_.setProperty(device_id, preset_id);
-	settings_.setString("device_preset_map", JSON::toString(device_preset_map_.clone().get()));
+	device_preset_map_->setProperty(device_id, preset_id);
+
+	juce::String jsonString = JSON::toString(device_preset_map_.getObject());
+	settings_.setString("device_preset_map", jsonString);
 }
 
 void FxController::removeDevicePreset(const String& device_id)
 {
-	device_preset_map_.removeProperty(device_id);
-	settings_.setString("device_preset_map", JSON::toString(device_preset_map_.clone().get()));
+	device_preset_map_->removeProperty(device_id);
+	juce::String jsonString = JSON::toString(device_preset_map_.getObject());
+	settings_.setString("device_preset_map", jsonString);
 }
 
 String FxController::getLanguage() const

--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -185,6 +185,30 @@ FxController::FxController() : message_window_(L"FxSoundHotkeys", (WNDPROC) even
     free_plan_ = settings_.getBool("free_plan");
     hide_help_tooltips_ = settings_.getBool("hide_help_tooltips");
 	hide_notifications_ = settings_.getBool("hide_notifications");
+
+	device_specific_preset_ = settings_.getBool("device_specific_preset");
+
+	DynamicObject* obj = new DynamicObject();
+	obj->setProperty("foo", "bar");
+	obj->setProperty("num", 123);
+
+	DynamicObject* nestedObj = new DynamicObject();
+	nestedObj->setProperty("inner", "value");
+	obj->setProperty("nested", nestedObj);
+
+	var json(obj); // store the outer object in a var [we could have done this earlier]
+	String s = JSON::toString(json);
+
+	String loaded_settings_string = settings_.getString("device_preset_map_");
+
+	auto parsed_device_preset_map = JSON::parse(loaded_settings_string);
+	String ad = JSON::toString(parsed_device_preset_map);
+
+	device_preset_map_ = parsed_device_preset_map.getDynamicObject()
+		? DynamicObject(*parsed_device_preset_map.getDynamicObject()->clone().get())
+		: DynamicObject();
+
+
     output_device_id_ = settings_.getString("output_device_id");
     output_device_name_ = settings_.getString("output_device_name");
 	max_user_presets_ = settings_.getInt("max_user_presets");
@@ -342,6 +366,24 @@ void FxController::init(FxMainWindow* main_window, FxSystemTrayView* system_tray
 		initPresets();
 		
 		auto preset_name = settings_.getString("preset");
+
+		bool device_specific_preset = settings_.getBool("device_specific_preset");
+		if (device_specific_preset)
+		{
+			String loaded_settings_string = settings_.getString("device_preset_map_");
+
+			auto parsed_device_preset_map = JSON::fromString(settings_.getString("device_preset_map_"));
+
+			device_preset_map_ = parsed_device_preset_map.getDynamicObject() != nullptr
+				? DynamicObject(*parsed_device_preset_map.getDynamicObject()->clone().get())
+				: DynamicObject();
+
+			if (device_preset_map_.hasProperty(output_device_id_))
+			{
+				preset_name = device_preset_map_.getProperty(output_device_id_);
+			}
+		}
+
         if (!authenticated_)
         {
             preset_name = "General";
@@ -566,6 +608,8 @@ bool FxController::setPreset(int selected_preset)
 
     auto preset = model.getPreset(selected_preset);
 
+	setDevicePreset(selected_device_id_, preset.name);
+
 	if (model.isPresetModified() && selected_preset != model.getSelectedPreset())
 	{
 		FxPresetSaveDialog preset_save_dialog;
@@ -672,6 +716,9 @@ void FxController::setOutput(int output, bool notify)
 
 		FxModel::getModel().pushMessage(TRANS("Output: ") + output_device_name_);
     }
+
+	selected_device_id_ = selected_sound_device.pwszID.c_str();
+	loadDevicePreset(selected_sound_device.pwszID.c_str());
 
 	FxModel::getModel().setSelectedOutput(output, selected_sound_device, notify);
 }
@@ -1142,6 +1189,29 @@ void FxController::setSelectedOutput(String id, String name)
 	}
 }
 
+
+void FxController::loadDevicePreset(String device_id)
+{
+	if (!isDeviceSpecificPreset())
+		return;
+
+	String saved_preset = getDevicePreset(device_id);
+
+	Array<FxModel::Preset> presets = FxModel::getModel().getPresets();
+
+	int saved_preset_index = -1;
+	for (auto i = 0; i < presets.size(); i++)
+	{
+		if (saved_preset.equalsIgnoreCase(presets[i].name))
+		{
+			saved_preset_index = i;
+		}
+	}
+
+	if (saved_preset_index >= 0)
+		setPreset(saved_preset_index);
+}
+
 float FxController::getEffectValue(FxEffects::EffectType effect)
 {
 	return dfx_dsp_.getEffectValue(static_cast<DfxDsp::Effect>(effect));
@@ -1601,6 +1671,35 @@ void FxController::setNotificationsHidden(bool status)
 {
 	hide_notifications_ = status;
 	settings_.setBool("hide_notifications", status);
+}
+bool FxController::isDeviceSpecificPreset()
+{
+	return device_specific_preset_;
+}
+
+void FxController::setDeviceSpecificPreset(bool status)
+{
+	device_specific_preset_ = status;
+	settings_.setBool("device_specific_preset", true);
+}
+
+String FxController::getDevicePreset(const String& device_id)
+{
+	return device_preset_map_.getProperty(device_id);
+}
+
+void FxController::setDevicePreset(const String& device_id, const String& preset_id)
+{
+	if (device_id == "")
+		return;
+	device_preset_map_.setProperty(device_id, preset_id);
+	settings_.setString("device_preset_map", JSON::toString(device_preset_map_.clone().get()));
+}
+
+void FxController::removeDevicePreset(const String& device_id)
+{
+	device_preset_map_.removeProperty(device_id);
+	settings_.setString("device_preset_map", JSON::toString(device_preset_map_.clone().get()));
 }
 
 String FxController::getLanguage() const

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -216,7 +216,7 @@ private:
 	bool output_changed_;
     bool playback_device_available_;
 	bool device_specific_preset_;
-	DynamicObject device_preset_map_;
+	juce::DynamicObject::Ptr device_preset_map_ = new juce::DynamicObject();
 	String output_device_id_;
 	String selected_device_id_; // represents fxview selection
     String output_device_name_;

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -116,6 +116,13 @@ public:
 	bool isNotificationsHidden();
 	void setNotificationsHidden(bool status);
 
+	bool isDeviceSpecificPreset();
+	void setDeviceSpecificPreset(bool status);
+
+	String getDevicePreset(const String& device_id);
+	void setDevicePreset(const String& device_id, const String& preset_id);
+	void removeDevicePreset(const String& device_id);
+
     String getLanguage() const;
     void setLanguage(String language_code);
     String getLanguageName(String language_code) const;
@@ -184,6 +191,7 @@ private:
     void selectOutput();
 	void updateOutputs(std::vector<SoundDevice>& sound_devices);
 	void setSelectedOutput(String id, String name);
+	void loadDevicePreset(String device_id);
 
 	void registerHotkeys();
 	void unregisterHotkeys();
@@ -207,7 +215,10 @@ private:
     bool free_plan_;
 	bool output_changed_;
     bool playback_device_available_;
+	bool device_specific_preset_;
+	DynamicObject device_preset_map_;
 	String output_device_id_;
+	String selected_device_id_; // represents fxview selection
     String output_device_name_;
     StringArray output_ids_;
 	std::vector<SoundDevice> output_devices_;

--- a/fxsound/Source/GUI/FxModel.cpp
+++ b/fxsound/Source/GUI/FxModel.cpp
@@ -152,6 +152,11 @@ FxModel::Preset FxModel::getPreset(int preset) const
 	return {};
 }
 
+Array<FxModel::Preset> FxModel::getPresets() const
+{
+	return presets_;
+}
+
 bool FxModel::isPresetModified() const
 {
 	return preset_modified_;

--- a/fxsound/Source/GUI/FxModel.h
+++ b/fxsound/Source/GUI/FxModel.h
@@ -77,6 +77,7 @@ public:
 	int getPresetCount() const;
 	int getUserPresetCount() const;
 	Preset getPreset(int preset) const;
+	Array<Preset> getPresets() const;
 	bool isPresetModified() const;
 	void setPresetModified(bool preset_modified);
     bool isPresetNameValid(const String& preset_name);

--- a/fxsound/Source/GUI/FxSettingsDialog.cpp
+++ b/fxsound/Source/GUI/FxSettingsDialog.cpp
@@ -476,6 +476,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	launch_toggle_(TRANS("Launch on system startup")),
 	hide_help_tips_toggle_(TRANS("Hide help tips for audio controls")),
 	hide_notifications_toggle_(TRANS("Hide notifications")),
+	device_specific_preset_toggle_(TRANS("Enable device specific preset")),
 	hotkeys_toggle_(TRANS("Disable keyboard shortcuts")),
 	reset_presets_button_(TRANS("Reset presets to factory defaults"))
 {
@@ -498,6 +499,10 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	hide_notifications_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hide_notifications_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hide_notifications_toggle_.setWantsKeyboardFocus(true);
+	device_specific_preset_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
+	device_specific_preset_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+	device_specific_preset_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+	device_specific_preset_toggle_.setWantsKeyboardFocus(true);
 	hotkeys_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
 	hotkeys_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hotkeys_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
@@ -539,6 +544,9 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	hide_notifications_toggle_.setToggleState(FxController::getInstance().isNotificationsHidden(), NotificationType::dontSendNotification);
 	hide_notifications_toggle_.onClick = [this]() { FxController::getInstance().setNotificationsHidden(hide_notifications_toggle_.getToggleState()); };
 
+	device_specific_preset_toggle_.setToggleState(FxController::getInstance().isDeviceSpecificPreset(), NotificationType::dontSendNotification);
+	device_specific_preset_toggle_.onClick = [this]() { FxController::getInstance().setDeviceSpecificPreset(device_specific_preset_toggle_.getToggleState()); };
+
 	reset_presets_button_.setSize(BUTTON_WIDTH, BUTTON_HEIGHT);
 	reset_presets_button_.setEnabled(FxModel::getModel().getUserPresetCount() > 0);
     reset_presets_button_.setMouseCursor(MouseCursor::PointingHandCursor);
@@ -555,6 +563,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	
 	addAndMakeVisible(&hide_help_tips_toggle_);
 	addAndMakeVisible(&hide_notifications_toggle_);
+	addAndMakeVisible(&device_specific_preset_toggle_);
 	addAndMakeVisible(&hotkeys_toggle_);
 	addAndMakeVisible(&reset_presets_button_);
 	addAndMakeVisible(&language_switch_);
@@ -586,6 +595,9 @@ void FxSettingsDialog::GeneralSettingsPane::resized()
 	hide_notifications_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
     y = hide_notifications_toggle_.getBottom() + 10;
+	device_specific_preset_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
+
+	y = device_specific_preset_toggle_.getBottom() + 10;
 	hotkeys_toggle_.setBounds(X_MARGIN, y, getWidth()-X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
 	y = hotkeys_toggle_.getBottom() + 5;
@@ -615,6 +627,7 @@ void FxSettingsDialog::GeneralSettingsPane::setText()
     launch_toggle_.setButtonText(TRANS("Launch on system startup"));
     hide_help_tips_toggle_.setButtonText(TRANS("Hide help tips for audio controls"));
 	hide_notifications_toggle_.setButtonText(TRANS("Hide notifications"));
+	device_specific_preset_toggle_.setButtonText(TRANS("Enable device specific preset"));
 
     hotkeys_toggle_.setButtonText(TRANS("Disable keyboard shortcuts"));
     reset_presets_button_.setButtonText(TRANS("Reset presets to factory defaults"));

--- a/fxsound/Source/GUI/FxSettingsDialog.h
+++ b/fxsound/Source/GUI/FxSettingsDialog.h
@@ -163,6 +163,7 @@ private:
         ToggleButton launch_toggle_;
         ToggleButton hide_help_tips_toggle_;
 		ToggleButton hide_notifications_toggle_;
+		ToggleButton device_specific_preset_toggle_;
 		ToggleButton hotkeys_toggle_;
 		TextButton reset_presets_button_;
 		OwnedArray<FxHotkeyLabel> hotkey_labels_;


### PR DESCRIPTION
Allow device specific presets setting to be toggled in the settings.
The selected presets are saved to the user settings and restored on startup, so the configuration persists across sessions.