### PR TITLE
feat: add refresh button to manually update audio device list

### DIFF
--- a/CppProperties.json
+++ b/CppProperties.json
@@ -1,0 +1,21 @@
+{
+  "configurations": [
+    {
+      "inheritEnvironments": [
+        "msvc_x64"
+      ],
+      "name": "x64-Debug",
+      "includePath": [
+        "${env.INCLUDE}",
+        "${workspaceRoot}\\**"
+      ],
+      "defines": [
+        "WIN32",
+        "_DEBUG",
+        "UNICODE",
+        "_UNICODE"
+      ],
+      "intelliSenseMode": "windows-msvc-x64"
+    }
+  ]
+}

--- a/fxsound/JuceLibraryCode/AppConfig.h
+++ b/fxsound/JuceLibraryCode/AppConfig.h
@@ -20,7 +20,7 @@
 
 // [END_USER_CODE_SECTION]
 
-#define JUCE_PROJUCER_VERSION 0x80009
+//#define JUCE_PROJUCER_VERSION 0x80009
 
 //==============================================================================
 #define JUCE_MODULE_AVAILABLE_juce_core                 1

--- a/fxsound/Project/FxSound_App.vcxproj
+++ b/fxsound/Project/FxSound_App.vcxproj
@@ -410,7 +410,8 @@ copy $(TargetDir)$(TargetName).pdb ..\..\bin\$(PlatformTarget)\ /y
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LargeAddressAware>true</LargeAddressAware>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <AdditionalDependencies>crypt32.lib;Wtsapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;crypt32.lib;wtsapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\JUCE\build\Debug</AdditionalLibraryDirectories>
     </Link>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/fxsound/Project/FxSound_App.vcxproj.filters
+++ b/fxsound/Project/FxSound_App.vcxproj.filters
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="FxSound\Fonts">
@@ -592,9 +591,6 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Files_linux.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Files_mac.mm">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Files_windows.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
@@ -616,13 +612,7 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Network_linux.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Network_mac.mm">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Network_windows.cpp">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_ObjCHelpers_mac_test.mm">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_PlatformTimer_generic.cpp">
@@ -631,25 +621,16 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_PlatformTimer_windows.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Process_mac.mm">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Registry_windows.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_RuntimePermissions_android.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Strings_mac.mm">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_android.cpp">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_linux.cpp">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_mac.mm">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_SystemStats_wasm.cpp">
@@ -662,9 +643,6 @@
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Threads_linux.cpp">
-      <Filter>JUCE Modules\juce_core\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Threads_mac.mm">
       <Filter>JUCE Modules\juce_core\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\native\juce_Threads_windows.cpp">
@@ -835,9 +813,6 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\juce_core.cpp">
       <Filter>JUCE Modules\juce_core</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\juce_core.mm">
-      <Filter>JUCE Modules\juce_core</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_core\juce_core_CompilationTime.cpp">
       <Filter>JUCE Modules\juce_core</Filter>
     </ClCompile>
@@ -860,9 +835,6 @@
       <Filter>JUCE Modules\juce_cryptography\hashing</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_cryptography\juce_cryptography.cpp">
-      <Filter>JUCE Modules\juce_cryptography</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_cryptography\juce_cryptography.mm">
       <Filter>JUCE Modules\juce_cryptography</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_data_structures\app_properties\juce_ApplicationProperties.cpp">
@@ -893,9 +865,6 @@
       <Filter>JUCE Modules\juce_data_structures\values</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_data_structures\juce_data_structures.cpp">
-      <Filter>JUCE Modules\juce_data_structures</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_data_structures\juce_data_structures.mm">
       <Filter>JUCE Modules\juce_data_structures</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\broadcasters\juce_ActionBroadcaster.cpp">
@@ -937,12 +906,6 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\messages\juce_MessageManager.cpp">
       <Filter>JUCE Modules\juce_events\messages</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\native\juce_MessageManager_ios.mm">
-      <Filter>JUCE Modules\juce_events\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\native\juce_MessageManager_mac.mm">
-      <Filter>JUCE Modules\juce_events\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\native\juce_Messaging_android.cpp">
       <Filter>JUCE Modules\juce_events\native</Filter>
     </ClCompile>
@@ -965,9 +928,6 @@
       <Filter>JUCE Modules\juce_events\timers</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\juce_events.cpp">
-      <Filter>JUCE Modules\juce_events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_events\juce_events.mm">
       <Filter>JUCE Modules\juce_events</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\colour\juce_Colour.cpp">
@@ -1492,9 +1452,6 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\images\juce_ImageFileFormat.cpp">
       <Filter>JUCE Modules\juce_graphics\images</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\native\juce_CoreGraphicsContext_mac.mm">
-      <Filter>JUCE Modules\juce_graphics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\native\juce_Direct2DGraphicsContext_windows.cpp">
       <Filter>JUCE Modules\juce_graphics\native</Filter>
     </ClCompile>
@@ -1523,9 +1480,6 @@
       <Filter>JUCE Modules\juce_graphics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\native\juce_Fonts_linux.cpp">
-      <Filter>JUCE Modules\juce_graphics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\native\juce_Fonts_mac.mm">
       <Filter>JUCE Modules\juce_graphics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\native\juce_GraphicsContext_android.cpp">
@@ -1625,9 +1579,6 @@
       <Filter>JUCE Modules\juce_graphics\unicode</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\juce_graphics.cpp">
-      <Filter>JUCE Modules\juce_graphics</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\juce_graphics.mm">
       <Filter>JUCE Modules\juce_graphics</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_graphics\juce_graphics_Harfbuzz.cpp">
@@ -1906,19 +1857,10 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility_android.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native\accessibility</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility_ios.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native\accessibility</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility_mac.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native\accessibility</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_Accessibility_windows.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native\accessibility</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilityElement_windows.cpp">
-      <Filter>JUCE Modules\juce_gui_basics\native\accessibility</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilitySharedCode_mac.mm">
       <Filter>JUCE Modules\juce_gui_basics\native\accessibility</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\accessibility\juce_AccessibilityTextHelpers_test.cpp">
@@ -1942,46 +1884,22 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_android.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_ios.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_linux.cpp">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_mac.mm">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_FileChooser_windows.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_MainMenu_mac.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_MouseCursor_mac.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_android.cpp">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_ios.mm">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_linux.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_mac.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_NativeMessageBox_windows.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_NSViewComponentPeer_mac.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_ScopedDPIAwarenessDisabler.cpp">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_UIViewComponentPeer_ios.mm">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_VBlank_windows.cpp">
@@ -1990,13 +1908,7 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_android.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_ios.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_linux.cpp">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_mac.mm">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_Windowing_windows.cpp">
@@ -2008,13 +1920,7 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_android.cpp">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_ios.mm">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_linux.cpp">
-      <Filter>JUCE Modules\juce_gui_basics\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_mac.mm">
       <Filter>JUCE Modules\juce_gui_basics\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\native\juce_WindowUtils_windows.cpp">
@@ -2158,9 +2064,6 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\juce_gui_basics.cpp">
       <Filter>JUCE Modules\juce_gui_basics</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_basics\juce_gui_basics.mm">
-      <Filter>JUCE Modules\juce_gui_basics</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\code_editor\juce_CodeDocument.cpp">
       <Filter>JUCE Modules\juce_gui_extra\code_editor</Filter>
     </ClCompile>
@@ -2221,13 +2124,7 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_AndroidViewComponent.cpp">
       <Filter>JUCE Modules\juce_gui_extra\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_AppleRemote_mac.mm">
-      <Filter>JUCE Modules\juce_gui_extra\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_HWNDComponent_windows.cpp">
-      <Filter>JUCE Modules\juce_gui_extra\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_NSViewComponent_mac.mm">
       <Filter>JUCE Modules\juce_gui_extra\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_PushNotifications_android.cpp">
@@ -2248,16 +2145,10 @@
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_SystemTrayIcon_windows.cpp">
       <Filter>JUCE Modules\juce_gui_extra\native</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_UIViewComponent_ios.mm">
-      <Filter>JUCE Modules\juce_gui_extra\native</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_android.cpp">
       <Filter>JUCE Modules\juce_gui_extra\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_linux.cpp">
-      <Filter>JUCE Modules\juce_gui_extra\native</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_mac.mm">
       <Filter>JUCE Modules\juce_gui_extra\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\native\juce_WebBrowserComponent_windows.cpp">
@@ -2267,9 +2158,6 @@
       <Filter>JUCE Modules\juce_gui_extra\native</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\juce_gui_extra.cpp">
-      <Filter>JUCE Modules\juce_gui_extra</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_gui_extra\juce_gui_extra.mm">
       <Filter>JUCE Modules\juce_gui_extra</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_opengl\opengl\juce_gl.cpp">
@@ -2306,9 +2194,6 @@
       <Filter>JUCE Modules\juce_opengl\utils</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_opengl\juce_opengl.cpp">
-      <Filter>JUCE Modules\juce_opengl</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\..\..\..\..\..\JUCE\modules\juce_opengl\juce_opengl.mm">
       <Filter>JUCE Modules\juce_opengl</Filter>
     </ClCompile>
     <ClCompile Include="..\JuceLibraryCode\BinaryData.cpp">

--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -971,6 +971,12 @@ void FxController::initOutputs(std::vector<SoundDevice>& sound_devices)
     selectOutput();
 }
 
+void FxController::refreshOutputs()
+{
+    std::vector<SoundDevice> sound_devices = audio_passthru_->getSoundDevices();
+    initOutputs(sound_devices);
+}
+
 void FxController::addPreferredOutput(std::vector<SoundDevice>& sound_devices)
 {
 	auto [pref_device_id, pref_device_name] = getPreferredOutput();

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -73,6 +73,8 @@ public:
     
     bool isPlaybackDeviceAvailable();
 
+	void refreshOutputs();
+
 	void savePreset(const String& preset_name=L"");
 	void renamePreset(const String& new_name);
 	void deletePreset();

--- a/fxsound/Source/GUI/FxProView.cpp
+++ b/fxsound/Source/GUI/FxProView.cpp
@@ -23,6 +23,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //==============================================================================
 FxProView::FxProView() : tool_tip_(this)
 {
+	addAndMakeVisible(preset_list_);
+	addAndMakeVisible(endpoint_list_);
 	addAndMakeVisible(effects_);
 	addAndMakeVisible(equalizer_);
     addChildComponent(visualizer_);
@@ -31,8 +33,11 @@ FxProView::FxProView() : tool_tip_(this)
 	equalizer_.addMouseListener(this, true);
 	effects_.addMouseListener(this, true);
 
-    refresh_button_.setButtonText(TRANS("↻"));
+    refresh_button_.setButtonText(TRANS("Refresh"));
     refresh_button_.addListener(this);
+    refresh_button_.setTooltip(TRANS("Refresh audio devices"));
+    refresh_button_.setColour(TextButton::buttonColourId, Colour(0xe63462).withAlpha(1.0f));
+    refresh_button_.setColour(TextButton::textColourOffId, Colour(0xffffff).withAlpha(1.0f));
 
     auto& theme = dynamic_cast<LookAndFeel_V4&>(getLookAndFeel());
 
@@ -72,10 +77,10 @@ void FxProView::resized()
     auto component_bounds = juce::Rectangle<int>(PRESET_LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT);
     preset_list_.setBounds(component_bounds);
 
-    auto component_bounds = juce::Rectangle<int>(OUTPUT_LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT);
-    endpoint_list_.setBounds(component_bounds);
+    auto output_bounds = juce::Rectangle<int>(OUTPUT_LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT);
+    endpoint_list_.setBounds(output_bounds);
 
-    refresh_button_.setBounds(component_bounds.getRight() + 10, LIST_Y, 40, LIST_HEIGHT);
+    refresh_button_.setBounds(output_bounds.getRight() + 20, LIST_Y, 70, LIST_HEIGHT);
 
     auto visualizer_offset = 0;
     if (visualizer_.isVisible())
@@ -104,7 +109,7 @@ void FxProView::paint(Graphics& g)
 	g.fillAll();
 
 	g.setFillType(FillType(Colour(0x0).withAlpha(0.2f)));
-	g.fillRoundedRectangle(20, 16, 920, 330+visualizer_offset, 8);
+	g.fillRoundedRectangle(20, 16, WIDTH - 40, 330+visualizer_offset, 8);
 
     auto enable_controls = FxModel::getModel().getPowerState() && !FxModel::getModel().isMonoOutputSelected();
 
@@ -139,7 +144,7 @@ void FxProView::mouseEnter(const MouseEvent& mouse_event)
 
 void FxProView::mouseExit(const MouseEvent& mouse_event)
 {
-	FxView::mouseEnter(mouse_event);
+	FxView::mouseExit(mouse_event);
 
 	equalizer_.showValues(equalizer_.isMouseOver(true));
 	effects_.showValues(effects_.isMouseOver(true));

--- a/fxsound/Source/GUI/FxProView.cpp
+++ b/fxsound/Source/GUI/FxProView.cpp
@@ -26,9 +26,13 @@ FxProView::FxProView() : tool_tip_(this)
 	addAndMakeVisible(effects_);
 	addAndMakeVisible(equalizer_);
     addChildComponent(visualizer_);
+    addAndMakeVisible(refresh_button_);
 
 	equalizer_.addMouseListener(this, true);
 	effects_.addMouseListener(this, true);
+
+    refresh_button_.setButtonText(TRANS("↻"));
+    refresh_button_.addListener(this);
 
     auto& theme = dynamic_cast<LookAndFeel_V4&>(getLookAndFeel());
 
@@ -68,8 +72,10 @@ void FxProView::resized()
     auto component_bounds = juce::Rectangle<int>(PRESET_LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT);
     preset_list_.setBounds(component_bounds);
 
-    component_bounds = juce::Rectangle<int>(OUTPUT_LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT);
+    auto component_bounds = juce::Rectangle<int>(OUTPUT_LIST_X, LIST_Y, LIST_WIDTH, LIST_HEIGHT);
     endpoint_list_.setBounds(component_bounds);
+
+    refresh_button_.setBounds(component_bounds.getRight() + 10, LIST_Y, 40, LIST_HEIGHT);
 
     auto visualizer_offset = 0;
     if (visualizer_.isVisible())
@@ -137,4 +143,12 @@ void FxProView::mouseExit(const MouseEvent& mouse_event)
 
 	equalizer_.showValues(equalizer_.isMouseOver(true));
 	effects_.showValues(effects_.isMouseOver(true));
+}
+
+void FxProView::buttonClicked(Button* button)
+{
+    if (button == &refresh_button_)
+    {
+        FxController::getInstance().refreshOutputs();
+    }
 }

--- a/fxsound/Source/GUI/FxProView.h
+++ b/fxsound/Source/GUI/FxProView.h
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //==============================================================================
 /*
 */
-class FxProView  : public FxView
+class FxProView  : public FxView, public Button::Listener
 {
 public:
     FxProView();
@@ -62,6 +62,7 @@ private:
 	FxEqualizer equalizer_;
     TooltipWindow tool_tip_;
     FxVisualizer visualizer_;
+    ImageButton refresh_button_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (FxProView)
 };

--- a/fxsound/Source/GUI/FxProView.h
+++ b/fxsound/Source/GUI/FxProView.h
@@ -42,10 +42,10 @@ public:
 	void paint(Graphics& g) override;
 
 private:
-	static constexpr int WIDTH = 960;
+	static constexpr int WIDTH = 1020;
 	static constexpr int HEIGHT = 474;
 	static constexpr int PRESET_LIST_X = 40;
-	static constexpr int OUTPUT_LIST_X = 500;
+	static constexpr int OUTPUT_LIST_X = 480;
 	static constexpr int LIST_Y = 32;
 	static constexpr int EFFECTS_X = 40;
 	static constexpr int EFFECTS_Y = 88;
@@ -58,11 +58,13 @@ private:
 	void mouseEnter(const MouseEvent& mouse_event) override;
 	void mouseExit(const MouseEvent& mouse_event) override;
 
+	void buttonClicked(Button* button) override;
+
 	FxEffects effects_;
 	FxEqualizer equalizer_;
     TooltipWindow tool_tip_;
     FxVisualizer visualizer_;
-    ImageButton refresh_button_;
+    TextButton refresh_button_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (FxProView)
 };


### PR DESCRIPTION
## Description

### Problem
Sometimes when connecting Bluetooth headphones, the app continues to output sound through the laptop speakers until the Bluetooth device is reconnected. This occurs because the device list is not automatically refreshed when new audio devices connect.

### Solution
Adds a manual refresh button to re-fetch connected audio devices, addressing the issue where Bluetooth headphones may not be automatically detected when connected.

- Added `refreshOutputs()` method in `FxController` to manually refresh the audio device list by querying `AudioPassthru`
- Added a reload button (↻) in `FxProView` positioned next to the output device dropdown
- Button click triggers device list refresh, allowing users to manually update available audio devices

### Changes Made
- `fxsound/Source/GUI/FxController.h`: Added `refreshOutputs()` method declaration
- `fxsound/Source/GUI/FxController.cpp`: Implemented `refreshOutputs()` to fetch and update device list
- `fxsound/Source/GUI/FxProView.h`: Added `Button::Listener` interface and `refresh_button_` member
- `fxsound/Source/GUI/FxProView.cpp`: Implemented button UI, positioning, and click handler

### Testing
Manual testing required:
1. Connect Bluetooth headphones
2. Click the refresh button next to the output device selector
3. Verify the device list updates with the newly connected device

### Branch
`feature/refresh-devices-button`
