### PR TITLE
feat(settings): Add "Remember preset per device" feature

### DIFF
--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -116,6 +116,9 @@ public:
 	bool isNotificationsHidden();
 	void setNotificationsHidden(bool status);
 
+	bool isPerDevicePresetEnabled() const;
+	void setPerDevicePresetEnabled(bool enabled);
+
     String getLanguage() const;
     void setLanguage(String language_code);
     String getLanguageName(String language_code) const;
@@ -215,6 +218,7 @@ private:
 	bool hide_notifications_;
 	bool volume_normalization_enabled_;
 	float volume_normalization_rms_;
+	bool per_device_preset_enabled_;
 
 	unsigned long audio_process_time_;
 	int audio_process_on_counter_;

--- a/fxsound/Source/GUI/FxSettingsDialog.cpp
+++ b/fxsound/Source/GUI/FxSettingsDialog.cpp
@@ -476,6 +476,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	launch_toggle_(TRANS("Launch on system startup")),
 	hide_help_tips_toggle_(TRANS("Hide help tips for audio controls")),
 	hide_notifications_toggle_(TRANS("Hide notifications")),
+	per_device_preset_toggle_(TRANS("Remember preset per device")),
 	hotkeys_toggle_(TRANS("Disable keyboard shortcuts")),
 	reset_presets_button_(TRANS("Reset presets to factory defaults"))
 {
@@ -498,6 +499,16 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	hide_notifications_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hide_notifications_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hide_notifications_toggle_.setWantsKeyboardFocus(true);
+
+	per_device_preset_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
+	per_device_preset_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+	per_device_preset_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
+	per_device_preset_toggle_.setWantsKeyboardFocus(true);
+	per_device_preset_toggle_.setToggleState(FxController::getInstance().isPerDevicePresetEnabled(), NotificationType::dontSendNotification);
+	per_device_preset_toggle_.onClick = [this]() {
+		FxController::getInstance().setPerDevicePresetEnabled(per_device_preset_toggle_.getToggleState());
+	};
+
 	hotkeys_toggle_.setMouseCursor(MouseCursor::PointingHandCursor);
 	hotkeys_toggle_.setColour(ToggleButton::ColourIds::tickColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
 	hotkeys_toggle_.setColour(ToggleButton::ColourIds::textColourId, getLookAndFeel().findColour(TextButton::textColourOnId));
@@ -555,6 +566,7 @@ FxSettingsDialog::GeneralSettingsPane::GeneralSettingsPane() :
 	
 	addAndMakeVisible(&hide_help_tips_toggle_);
 	addAndMakeVisible(&hide_notifications_toggle_);
+	addAndMakeVisible(&per_device_preset_toggle_);
 	addAndMakeVisible(&hotkeys_toggle_);
 	addAndMakeVisible(&reset_presets_button_);
 	addAndMakeVisible(&language_switch_);
@@ -585,7 +597,10 @@ void FxSettingsDialog::GeneralSettingsPane::resized()
 	y = hide_help_tips_toggle_.getBottom() + 10;
 	hide_notifications_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
-    y = hide_notifications_toggle_.getBottom() + 10;
+	y = hide_notifications_toggle_.getBottom() + 10;
+	per_device_preset_toggle_.setBounds(X_MARGIN, y, getWidth() - X_MARGIN, TOGGLE_BUTTON_HEIGHT);
+
+	y = per_device_preset_toggle_.getBottom() + 10;
 	hotkeys_toggle_.setBounds(X_MARGIN, y, getWidth()-X_MARGIN, TOGGLE_BUTTON_HEIGHT);
 
 	y = hotkeys_toggle_.getBottom() + 5;
@@ -615,6 +630,7 @@ void FxSettingsDialog::GeneralSettingsPane::setText()
     launch_toggle_.setButtonText(TRANS("Launch on system startup"));
     hide_help_tips_toggle_.setButtonText(TRANS("Hide help tips for audio controls"));
 	hide_notifications_toggle_.setButtonText(TRANS("Hide notifications"));
+	per_device_preset_toggle_.setButtonText(TRANS("Remember preset per device"));
 
     hotkeys_toggle_.setButtonText(TRANS("Disable keyboard shortcuts"));
     reset_presets_button_.setButtonText(TRANS("Reset presets to factory defaults"));

--- a/fxsound/Source/GUI/FxSettingsDialog.h
+++ b/fxsound/Source/GUI/FxSettingsDialog.h
@@ -163,6 +163,7 @@ private:
         ToggleButton launch_toggle_;
         ToggleButton hide_help_tips_toggle_;
 		ToggleButton hide_notifications_toggle_;
+		ToggleButton per_device_preset_toggle_;
 		ToggleButton hotkeys_toggle_;
 		TextButton reset_presets_button_;
 		OwnedArray<FxHotkeyLabel> hotkey_labels_;


### PR DESCRIPTION
## Device-specific preset switching (optional)

Add an optional setting to make presets **output-device specific**.

When enabled:
- Each audio output device remembers its last-used preset
- Presets automatically switch when the output device changes

When disabled:
- Keep current global preset behavior