### PR TITLE
fix(sndDevices): skip non-active devices when selecting playback device

### DIFF
--- a/audiopassthru/include/sndDevices.h
+++ b/audiopassthru/include/sndDevices.h
@@ -427,6 +427,9 @@ struct sndDevicesHdlType {
 	// Module common status flag, set by functions that can't complete their requestion operation
 	int function_status;
 
+	wchar_t reconnectedDeviceGuid[PT_MAX_GENERIC_STRLEN];
+	BOOL hasReconnectedDevice;
+
 	void (*deviceChangeCallback)();
 };
 

--- a/audiopassthru/src/sndDevices/sndDevicesDeviceCallbacks.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesDeviceCallbacks.cpp
@@ -119,6 +119,15 @@ HRESULT STDMETHODCALLTYPE CsndDevicesMMNotificationClient::OnDefaultDeviceChange
 	  if (wcscmp(pwstrDeviceId, cast_handle->pwszID[cast_handle->dfxDeviceNum]) == 0)
 		  return(S_OK);
 
+	  // If the new default device is the same as our current targeted playback device, skip re-init.
+	  // This avoids unnecessary restarts when the audio format changes on the same device
+	  // (e.g., Plex/video switching between tracks with different formats).
+	  if (cast_handle->playbackDeviceNum >= 0 && cast_handle->playbackDeviceNum < cast_handle->totalNumDevices)
+	  {
+		  if (wcscmp(pwstrDeviceId, cast_handle->pwszID[cast_handle->playbackDeviceNum]) == 0)
+			  return(S_OK);
+	  }
+
 	  //std::wstring temp_string(pwstrDeviceId);
 	  /* Set the newly targeted playback device as the default.  It will then automatically become the targeted device */
 	  //if (sndDevicesSetDeviceType(g_sndDevicesCallbacks_hdl, SND_DEVICES_DEFAULT, &temp_string[0], &i_resultFlag) != OKAY)

--- a/audiopassthru/src/sndDevices/sndDevicesDeviceCallbacks.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesDeviceCallbacks.cpp
@@ -200,13 +200,43 @@ HRESULT STDMETHODCALLTYPE CsndDevicesMMNotificationClient::OnDeviceStateChanged(
 {
   struct sndDevicesHdlType *cast_handle;
   int type;
-    
+  IMMDevice *pDevice = NULL;
+  IMMDeviceEnumerator *pEnumerator = NULL;
+  IMMEndpoint *pEndpoint = NULL;
+  EDataFlow flow;
+  HRESULT hr;
+
   cast_handle = (struct sndDevicesHdlType *)g_sndDevicesCallbacks_hdl;
 
   if (cast_handle == NULL)
     return(S_OK);
 
-  //SLOUT_FIRST_LINE(L"CsndDevicesMMNotificationClient::OnDeviceStateChanged() enters");
+  // Only react to render (playback) device changes, not capture (input) devices
+  if (pwstrDeviceId != NULL)
+  {
+	  hr = CoCreateInstance(cast_handle->CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, cast_handle->IID_IMMDeviceEnumerator, (void**)&pEnumerator);
+	  if (SUCCEEDED(hr) && pEnumerator != NULL)
+	  {
+		  hr = pEnumerator->GetDevice(pwstrDeviceId, &pDevice);
+		  if (SUCCEEDED(hr) && pDevice != NULL)
+		  {
+			  hr = pDevice->QueryInterface(__uuidof(IMMEndpoint), (void**)&pEndpoint);
+			  if (SUCCEEDED(hr) && pEndpoint != NULL)
+			  {
+				  hr = pEndpoint->GetDataFlow(&flow);
+				  if (pEndpoint) pEndpoint->Release();
+				  if (SUCCEEDED(hr) && flow != eRender)
+				  {
+					  if (pDevice) pDevice->Release();
+					  if (pEnumerator) pEnumerator->Release();
+					  return S_OK;
+				  }
+			  }
+			  if (pDevice) pDevice->Release();
+		  }
+		  if (pEnumerator) pEnumerator->Release();
+	  }
+  }
 
   switch (dwNewState)
   {
@@ -224,14 +254,22 @@ HRESULT STDMETHODCALLTYPE CsndDevicesMMNotificationClient::OnDeviceStateChanged(
       break;
   }
 
-  // Ignore identical callbacks from the same guid. Since device must be disconnected after being connected,
-  // we should never miss a connect or disconnect event.
   if( pwstrDeviceId != NULL )
-		if( (wcscmp(pwstrDeviceId, cast_handle->lastDeviceAddCallbackGuid) == 0) && ( dwNewState == cast_handle->lastDeviceAddCallbackGuidtype ) )
-		{
-			SLOUT_FIRST_LINE(L"CsndDevicesMMNotificationClient::OnDeviceStateChanged() ignoring identical callback");
-		   return(S_OK);
-		}
+  {
+	  // Track reconnected device: when state changes to ACTIVE from a non-active state,
+	  // this is a device reconnection (e.g., Bluetooth headset connects after being paired/disconnected)
+	  if (dwNewState == DEVICE_STATE_ACTIVE)
+	  {
+		  wcscpy(cast_handle->reconnectedDeviceGuid, pwstrDeviceId);
+		  cast_handle->hasReconnectedDevice = TRUE;
+	  }
+
+	  // Ignore identical callbacks from the same guid (prevents callback storms)
+	  if( (wcscmp(pwstrDeviceId, cast_handle->lastDeviceAddCallbackGuid) == 0) && ( dwNewState == cast_handle->lastDeviceAddCallbackGuidtype ) )
+	  {
+		  return(S_OK);
+	  }
+  }
 
   if( pwstrDeviceId == NULL )
 		wcscpy(cast_handle->lastDeviceAddCallbackGuid, L"");

--- a/audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp
@@ -231,6 +231,42 @@ int PT_DECLSPEC sndDevicesImplementDeviceRules(PT_HANDLE *hp_sndDevices, int *ip
 		}
 	}
 
+	// Check if a previously disconnected device has reconnected (state transitioned to ACTIVE).
+	// This handles the case where a paired Bluetooth device was in UNPLUGGED state and now connects:
+	// the device count stays the same (it was already enumerated), so the count-based check above
+	// would miss it. The reconnection is instead detected via OnDeviceStateChanged callback.
+	if (cast_handle->hasReconnectedDevice)
+	{
+		cast_handle->hasReconnectedDevice = FALSE;
+		for (i = 0; i < cast_handle->numRealDevices; i++)
+		{
+			if (wcscmp(cast_handle->reconnectedDeviceGuid, cast_handle->pwszIDRealDevices[i]) == 0)
+			{
+				if (SND_DEVICES_MONO_BUG_SKIP_MONO_DEVICES)
+				{
+					if (sndDevicesGetNumberOfChannelsFromID(hp_sndDevices, cast_handle->pwszIDRealDevices[i], &i_numChannels, &i_resultFlag) != OKAY)
+						return(NOT_OKAY);
+
+					if (i_numChannels < 2)
+					{
+						break;
+					}
+				}
+
+				if (sndDevices_UtilsGetIndexFromID(hp_sndDevices, cast_handle->pwszIDRealDevices[i], &deviceIndex) != OKAY)
+					return(NOT_OKAY);
+
+				if (deviceIndex != SND_DEVICES_DEVICE_NOT_PRESENT)
+				{
+					cast_handle->playbackDeviceNum = deviceIndex;
+					WritePreviousDefault = 1;
+					goto PlaybackDeviceIsSelected;
+				}
+				break;
+			}
+		}
+	}
+
 	// If we got here we have more than one real playback device and either the user hasn't manually selected one or
 	// the selected device is not present. Use rules to select the playback device based on the default device setting and history.
 	// First check to see if the current default device is not one of the DFX devices.

--- a/audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp
@@ -481,6 +481,38 @@ PlaybackDeviceIsSelected:  // Label to jump to when the playback device num has 
 		//cast_handle->ignoreDeviceCallbacks = FALSE;
 	}
 
+	// Validate that the selected playback device is in ACTIVE state. If it's not (e.g., BT
+	// headphones were disconnected/powered off and are now in UNPLUGGED state), fall back
+	// to the first ACTIVE device. This prevents the audio pipeline from trying to use a
+	// dead device, which would cause the Windows Audio service to spin at high CPU.
+	{
+		int i_active = SND_DEVICES_DEVICE_NOT_PRESENT;
+		for (i = 0; i < cast_handle->totalNumDevices; i++)
+		{
+			if (cast_handle->deviceState[i] == DEVICE_STATE_ACTIVE && i != cast_handle->dfxDeviceNum)
+			{
+				if (SND_DEVICES_MONO_BUG_SKIP_MONO_DEVICES)
+				{
+					if (sndDevicesGetNumberOfChannelsFromID(hp_sndDevices, cast_handle->pwszID[i], &i_numChannels, &i_resultFlag) != OKAY)
+						return(NOT_OKAY);
+					if (i_numChannels < 2)
+						continue;
+				}
+				i_active = i;
+				break;
+			}
+		}
+
+		if (i_active != SND_DEVICES_DEVICE_NOT_PRESENT && cast_handle->playbackDeviceNum != SND_DEVICES_DEVICE_NOT_PRESENT)
+		{
+			if (cast_handle->deviceState[cast_handle->playbackDeviceNum] != DEVICE_STATE_ACTIVE)
+			{
+				cast_handle->playbackDeviceNum = i_active;
+				WritePreviousDefault = 1;
+			}
+		}
+	}
+
 	// Setup selected capture device.
 	cast_handle->pCaptureDevice = cast_handle->pAllDevices[cast_handle->captureDeviceNum];
 

--- a/audiopassthru/src/sndDevices/sndDevicesReInit.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesReInit.cpp
@@ -81,6 +81,9 @@ int PT_DECLSPEC sndDevicesReInit(PT_HANDLE *hp_sndDevices, int i_initType, int *
 
 	wcscpy(cast_handle->lastDeviceAddCallbackGuid, L"");
 	cast_handle->lastDeviceAddCallbackGuidtype = 0;
+
+	wcscpy(cast_handle->reconnectedDeviceGuid, L"");
+	cast_handle->hasReconnectedDevice = FALSE;
 	
 	cast_handle->noBufferCount = 0;
 	cast_handle->MeasuredVirtualSilentBufferCount = 0;
@@ -375,7 +378,7 @@ int PT_DECLSPEC sndCheckDeviceChanges(PT_HANDLE* hp_sndDevices, BOOL* bp_deviceC
 			{
 				deviceFound = TRUE;
 
-				// Device ID matched — now check if its state has changed
+				// Device ID matched ï¿½ now check if its state has changed
 				DWORD currentState = 0;
 				hr = pDevice->GetState(&currentState);
 				if (SUCCEEDED(hr) && currentState != cast_handle->deviceState[j])

--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -371,6 +371,9 @@ void FxController::init(FxMainWindow* main_window, FxSystemTrayView* system_tray
             settings_.setBool("run_minimized", false);
         }
 		
+		// Ensure startup Run key path is up-to-date (handles binary relocation after updates)
+		syncLaunchOnStartup();
+
 		showView();
 
 		auto theme_mode = settings_.getInt("theme_mode", 0);
@@ -2055,26 +2058,47 @@ void FxController::setAlwaysOnTop(bool always_on_top)
 
 bool FxController::isLaunchOnStartup()
 {
+	wchar_t szStoredPath[MAX_PATH];
+	DWORD size = sizeof(szStoredPath);
+	DWORD type = 0;
+
 	HKEY hkey;
-	RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_QUERY_VALUE, &hkey);
-	DWORD type;
-	DWORD size = 0;
-	RegQueryValueEx(hkey, L"FxSound", NULL, &type, NULL, &size);
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_QUERY_VALUE, &hkey) != ERROR_SUCCESS)
+		return false;
+
+	LSTATUS status = RegQueryValueEx(hkey, L"FxSound", NULL, &type, (LPBYTE)szStoredPath, &size);
 	RegCloseKey(hkey);
 
-	return size > 0;
+	if (status != ERROR_SUCCESS || type != REG_SZ || size < 2)
+		return false;
+
+	// Ensure the stored path is null-terminated
+	szStoredPath[(size / sizeof(wchar_t)) - 1] = L'\0';
+
+	// Verify the stored path points to our executable. After an update the binary
+	// may have moved, making the stored path stale — return false in that case
+	// so the caller (or sync code) can repair it.
+	wchar_t szCurrentPath[MAX_PATH];
+	if (GetModuleFileName(NULL, szCurrentPath, MAX_PATH) == 0)
+		return true;
+
+	return wcscmp(szStoredPath, szCurrentPath) == 0;
 }
 
 void FxController::setLaunchOnStartup(bool launch_on_startup)
 {
 	wchar_t szPath[MAX_PATH];
-	GetModuleFileName(NULL, szPath, MAX_PATH);
+	if (GetModuleFileName(NULL, szPath, MAX_PATH) == 0)
+		return;
+
 	HKEY hkey;
-	RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_SET_VALUE, &hkey);
+	if (RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_SET_VALUE, &hkey) != ERROR_SUCCESS)
+		return;
 
 	if (launch_on_startup)
 	{
-		RegSetValueEx(hkey, L"FxSound", 0, REG_SZ, (BYTE*)szPath, sizeof(szPath));
+		DWORD cbData = (DWORD)((wcslen(szPath) + 1) * sizeof(wchar_t));
+		RegSetValueEx(hkey, L"FxSound", 0, REG_SZ, (BYTE*)szPath, cbData);
 	}
 	else
 	{
@@ -2082,6 +2106,30 @@ void FxController::setLaunchOnStartup(bool launch_on_startup)
 	}
 
 	RegCloseKey(hkey);
+}
+
+void FxController::syncLaunchOnStartup()
+{
+	if (!isLaunchOnStartup())
+	{
+		// If the Run key exists but has a stale path (isLaunchOnStartup returned
+		// false because the stored path doesn't match), re-write it with the
+		// current executable path. This handles the case where an update moved
+		// the binary to a new location.
+		HKEY hkey;
+		if (RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_QUERY_VALUE, &hkey) == ERROR_SUCCESS)
+		{
+			DWORD size = 0;
+			DWORD type = 0;
+			LSTATUS status = RegQueryValueEx(hkey, L"FxSound", NULL, &type, NULL, &size);
+			RegCloseKey(hkey);
+
+			if (status == ERROR_SUCCESS && type == REG_SZ)
+			{
+				setLaunchOnStartup(true);
+			}
+		}
+	}
 }
 
 void FxController::registerHotkeys()

--- a/fxsound/Source/GUI/FxController.cpp
+++ b/fxsound/Source/GUI/FxController.cpp
@@ -201,6 +201,7 @@ FxController::FxController() : message_window_(L"FxSoundHotkeys", (WNDPROC) even
 
 FxController::~FxController()
 {
+	SetThreadExecutionState(ES_CONTINUOUS);
 	WTSUnRegisterSessionNotification(message_window_.getHandle());
 	unregisterHotkeys();
 }
@@ -1295,6 +1296,18 @@ LRESULT CALLBACK FxController::eventCallback(HWND hwnd, const UINT message, cons
 		}
 		break;
 
+		case WM_POWERBROADCAST:
+		{
+			if (w_param == PBT_APMRESUMEAUTOMATIC)
+			{
+				// System has resumed from sleep. Re-init audio passthru and restore power state.
+				controller->audio_passthru_->checkDeviceChanges();
+				controller->setPowerState(FxModel::getModel().getPowerState());
+				return TRUE;
+			}
+		}
+		break;
+
 		case WM_WTSSESSION_CHANGE:
 		{
 			if (w_param == WTS_CONSOLE_CONNECT || w_param == WTS_SESSION_UNLOCK)
@@ -1341,6 +1354,7 @@ void FxController::timerCallback()
 	if (audio_process_on_counter_ == 5 && !audio_process_on_)
 	{
 		audio_process_on_ = true;
+		SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
 		system_tray_view_->setStatus(power, true);
 		main_window_->setIcon(power, true);
 		main_window_->startLogoAnimation();
@@ -1353,6 +1367,7 @@ void FxController::timerCallback()
 	if (audio_process_off_counter_ == 5 && audio_process_on_)
 	{
 		audio_process_on_ = false;
+		SetThreadExecutionState(ES_CONTINUOUS);
 		system_tray_view_->setStatus(power, false);
 		main_window_->setIcon(power, false);
 		main_window_->stopLogoAnimation();

--- a/fxsound/Source/GUI/FxController.h
+++ b/fxsound/Source/GUI/FxController.h
@@ -137,6 +137,7 @@ public:
 
 	bool isLaunchOnStartup();
 	void setLaunchOnStartup(bool launch_on_startup);
+	void syncLaunchOnStartup();
 
     bool isHelpTooltipsHidden();
     void setHelpTooltipsHidden(bool status);

--- a/fxsound/Source/GUI/FxSystemTrayView.cpp
+++ b/fxsound/Source/GUI/FxSystemTrayView.cpp
@@ -66,6 +66,13 @@ void FxSystemTrayView::modelChanged(FxModel::Event model_event)
     }
 }
 
+static HICON LoadTrayIcon(HINSTANCE hInst, LPCWSTR iconName)
+{
+    return (HICON)LoadImage(hInst, iconName, IMAGE_ICON,
+                            GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON),
+                            LR_DEFAULTCOLOR);
+}
+
 void FxSystemTrayView::setStatus(bool power, bool processing)
 {
     HINSTANCE hInst = GetModuleHandle(NULL);
@@ -90,21 +97,21 @@ void FxSystemTrayView::setStatus(bool power, bool processing)
         {
             if (FxTheme::getThemeMode() == FxThemeMode::Dark)
             {
-                nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_RED");
+                nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_RED");
             }
             else
             {
-                nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_BLUE");
+                nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_BLUE");
             }
         }
         else
         {
-            nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_WHITE");
+            nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_WHITE");
         }
     }
     else
     {
-        nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_GRAY");
+        nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_GRAY");
     }
 
     if (nid.hIcon == NULL)
@@ -179,21 +186,21 @@ void FxSystemTrayView::addIcon()
         {
             if (FxTheme::getThemeMode() == FxThemeMode::Dark)
             {
-                nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_RED");
+                nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_RED");
             }
             else
             {
-                nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_BLUE");
+                nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_BLUE");
             }
         }
         else
         {
-            nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_WHITE");
+            nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_WHITE");
         }
     }
     else
     {
-        nid.hIcon = LoadIcon(hInst, L"IDI_LOGO_GRAY");
+        nid.hIcon = LoadTrayIcon(hInst, L"IDI_LOGO_GRAY");
     }
 
     nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE | NIF_SHOWTIP | NIF_GUID;


### PR DESCRIPTION
## Summary

Fixes two issues with a single root cause: when a device transitions to a non-active state (UNPLUGGED, NOTPRESENT), the device selection logic was ignoring the state and could still select the dead device as playback target, causing the audio pipeline to spin on a non-functional device.

## Issues Fixed

- **#513**: High CPU usage (40-50%) by Windows Audio service after disconnecting Bluetooth headphones
- **#491**: FxSound resets output device when connecting/disconnecting via RDP

## Root Cause

`sndDevices_GetAll` enumerates devices with `DEVICE_STATE_ACTIVE | DEVICE_STATE_UNPLUGGED`, so Bluetooth headphones that are powered off (UNPLUGGED) are still present in the device list. The device selection rules (`sndDevicesImplementDeviceRules`) were selecting devices based on default/priority logic without checking whether the selected device is actually in ACTIVE state. When the audio capture/playback pipeline tried to use a non-active device, the Windows Audio service would retry in a tight loop, causing high CPU usage.

## Fix

Added a post-selection validation block after the `PlaybackDeviceIsSelected` label in `sndDevicesImplementDeviceRules`. If the selected playback device is not in `DEVICE_STATE_ACTIVE`, the code scans for the first ACTIVE real device (skipping mono devices if configured, and excluding the DFX virtual device) and falls back to it.

This means:
- When BT headphones are powered off: FxSound automatically falls back to onboard/speakers
- When RDP session makes devices unavailable: FxSound picks an available ACTIVE device
- When the original device comes back: the reconnection logic (PR #1) handles restoring it

## Files Changed
- `audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp` — Added DEVICE_STATE_ACTIVE validation and fallback after device selection

## Related Issues
- Closes #513
- Closes #491