### PR TITLE
feat: run the virtual device at the output sample rate, up to 192 kHz

### DIFF
--- a/audiopassthru/include/sndDevices.h
+++ b/audiopassthru/include/sndDevices.h
@@ -169,10 +169,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SND_DEVICES_REGISTRY_DFX_GUID								L"dfx_guid"
 #define SND_DEVICES_REGISTRY_DEFAULT_BUFFER_SIZE				L"default_buffer_size"
 
-/* Dfx Device sample freq flags */
-#define SND_DEVICES_DFX_SAMP_FREQ_44_1			0
-#define SND_DEVICES_DFX_SAMP_FREQ_48			1
-
 /* Controls the period in MS where following device callbacks are ignored */
 #define SND_DEVICES_CALLBACK_TIME_WINDOW		0
 /* Controls the time in MS that the callbacks wait before setting reset flag */
@@ -186,6 +182,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /* Time to wait in millisecs for the encoding thread termination to complete */
 #define SND_DEVICES_MAX_WAIT_FOR_ENCODING_THREAD_TERMINATION 1000
 
+#define SND_DEVICES_MIN_SAMP_FREQ 44100
 #define SND_DEVICES_MAX_SAMP_FREQ 192000
 #define SND_DEVICES_MIN_NUM_CHANS 2
 #define SND_DEVICES_MAX_NUM_CHANS 8
@@ -323,6 +320,8 @@ public:
 };
 
 
+class Resampler;
+
 struct sndDevicesHdlType {
    
 	/* Message info */
@@ -399,6 +398,7 @@ struct sndDevicesHdlType {
     UINT32 numPlaybackFramesAvailableToFill;	// The number of open frames available to fill in the system playback buffer.
 
 	UINT32 upsampleRatio;
+	Resampler *playbackResampler; // Upsamples processed frames to the playback rate.
 	float sigPower;
 	int bufferSizeMilliSecs;		// This is the average delay, actual internal buffers are twice this length.
 	//int playback_has_started;

--- a/audiopassthru/src/sndDevices/sndDevicesDoPlayback.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesDoPlayback.cpp
@@ -35,6 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mry.h"
 #include "u_sndDevices.h"
 #include "sndDevices.h"
+#include "Resampler.h"
 
 /*
  * FUNCTION: sndDevicesDoPlayback()
@@ -46,10 +47,9 @@ int PT_DECLSPEC sndDevicesDoPlayback(PT_HANDLE *hp_sndDevices, int *ip_resultFla
 	struct sndDevicesHdlType *cast_handle;
 	HRESULT hr;
 	UINT32 numFramesQueuedUpToPlay;
-	UINT32 i, j, index, loopsize;
+	UINT32 i, loopsize;
 	DWORD flags = 0;
 	int numPlaybackChannels;
-	int k;
 
 	float *fptr;
 
@@ -66,28 +66,9 @@ int PT_DECLSPEC sndDevicesDoPlayback(PT_HANDLE *hp_sndDevices, int *ip_resultFla
 
 	numPlaybackChannels = cast_handle->wfxPlayback.nChannels;
 
-	// Do upsampling if needed.
-	if( cast_handle->upsampleRatio > 1 )
-	{
-		// Copy channel corrected playback buffers back to capture buffer so we can then re-sample.
-		loopsize = cast_handle->capturedFramesCount * numPlaybackChannels;
-		for(i=0; i<loopsize; i++)
-			cast_handle->fCaptureBuf[i] = cast_handle->fPlaybackBuf[i];
-
-		// Fill playback buff with upsampling
-		index = 0;
-		for(i=0; i<cast_handle->capturedFramesCount; i++) // Index through frames (sample sets)
-		{
-			for(j=0; j<cast_handle->upsampleRatio; j++)	 // Repeat frame fills for upsampling
-			{
-				for(k=0; k<numPlaybackChannels; k++)
-				{
-					cast_handle->fPlaybackBuf[index] = cast_handle->fCaptureBuf[i * numPlaybackChannels + k];
-					index++;
-				}
-			}
-		}
-	}
+	// Bring the processed frames up from the DFX device rate to the playback rate.
+	if( (cast_handle->upsampleRatio > 1) && (cast_handle->playbackResampler != NULL) )
+		cast_handle->playbackResampler->interpolate(cast_handle->fPlaybackBuf, (int)cast_handle->capturedFramesCount, cast_handle->fPlaybackBuf);
 
 	// This call returns the number of frames still awaiting playback in the playback buffer
 	hr = cast_handle->pAudioClientPlayback->GetCurrentPadding(&numFramesQueuedUpToPlay);

--- a/audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesImplementDeviceRules.cpp
@@ -60,6 +60,7 @@ int PT_DECLSPEC sndDevicesImplementDeviceRules(PT_HANDLE *hp_sndDevices, int *ip
 	int playbackSamplingFrequency;
 	int captureSamplingFrequency;
 	int numCaptureChannels;
+	int fallbackRate;
 	int deviceIndex;
 	int resultFlag;
 	int i, j;
@@ -416,16 +417,19 @@ PlaybackDeviceIsSelected:  // Label to jump to when the playback device num has 
 	if( numCaptureChannels > SND_DEVICES_MAX_NUM_CHANS )
 		numCaptureChannels = SND_DEVICES_MAX_NUM_CHANS;
 
-	if( (playbackSamplingFrequency % 48000) == 0 )
+	// Run the DFX device at the playback rate, or at its 44.1k/48k family rate if the driver refuses.
+	fallbackRate = ((playbackSamplingFrequency % 48000) == 0) ? 48000 : 44100;
+	captureSamplingFrequency = playbackSamplingFrequency;
+	if( (captureSamplingFrequency < SND_DEVICES_MIN_SAMP_FREQ) || (captureSamplingFrequency > SND_DEVICES_MAX_SAMP_FREQ) )
+		captureSamplingFrequency = fallbackRate;
+
+	if( sndDevicesSetDfxDeviceSampleRateAndChannels(hp_sndDevices, captureSamplingFrequency, numCaptureChannels, &resultFlag) != OKAY )
+		return(NOT_OKAY);
+
+	if( (resultFlag == SND_DEVICES_DEVICE_SET_FORMAT_FAILED) && (captureSamplingFrequency != fallbackRate) )
 	{
-		captureSamplingFrequency = 48000;
-		if( sndDevicesSetDfxDeviceSampleRateAndChannels(hp_sndDevices, SND_DEVICES_DFX_SAMP_FREQ_48, numCaptureChannels, &resultFlag) != OKAY )
-			return(NOT_OKAY);
-	}
-	else
-	{
-		captureSamplingFrequency = 44100;
-		if( sndDevicesSetDfxDeviceSampleRateAndChannels(hp_sndDevices, SND_DEVICES_DFX_SAMP_FREQ_44_1, numCaptureChannels, &resultFlag) != OKAY )
+		captureSamplingFrequency = fallbackRate;
+		if( sndDevicesSetDfxDeviceSampleRateAndChannels(hp_sndDevices, captureSamplingFrequency, numCaptureChannels, &resultFlag) != OKAY )
 			return(NOT_OKAY);
 	}
 

--- a/audiopassthru/src/sndDevices/sndDevicesInit.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesInit.cpp
@@ -36,6 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "mry.h"
 #include "u_sndDevices.h"
 #include "sndDevices.h"
+#include "Resampler.h"
 
 /*
  * FUNCTION: sndDevicesInit()
@@ -84,6 +85,7 @@ int PT_DECLSPEC sndDevicesInit(PT_HANDLE *hp_sndDevices, CSlout *hp_slout, int i
 	cast_handle->fFilePlaybackBuf = NULL;
 	cast_handle->captureBufAllocSize  = 0;
 	cast_handle->playbackBufAllocSize = 0;
+	cast_handle->playbackResampler = NULL;
 
 	cast_handle->initializationMode = i_initType;
 
@@ -260,6 +262,9 @@ int PT_DECLSPEC sndDevicesFree(PT_HANDLE *hp_sndDevices)
 
 		if( cast_handle->fFilePlaybackBuf != NULL )
 			free( cast_handle->fFilePlaybackBuf );
+
+		delete cast_handle->playbackResampler;
+		cast_handle->playbackResampler = NULL;
 	}
 	
 	hr = CoCreateInstance(cast_handle->CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, cast_handle->IID_IMMDeviceEnumerator, (void**)&pEnumerator);

--- a/audiopassthru/src/sndDevices/sndDevicesReInit.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesReInit.cpp
@@ -31,6 +31,51 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "reg.h"
 #include "u_sndDevices.h"
 #include "sndDevices.h"
+#include <new>
+#include "Resampler.h"
+
+/*
+ * FUNCTION: sndDevices_SetupPlaybackResampler()
+ * DESCRIPTION: Prepares the interpolator used when the DFX device runs below the playback rate.
+ */
+static int sndDevices_SetupPlaybackResampler(PT_HANDLE *hp_sndDevices)
+{
+	struct sndDevicesHdlType *cast_handle;
+	int numChannels;
+	int upsampleFactor;
+	int maxFrames;
+
+	cast_handle = (struct sndDevicesHdlType *)hp_sndDevices;
+
+	numChannels = cast_handle->wfxPlayback.nChannels;
+
+	if ((cast_handle->upsampleRatio <= 1) || (numChannels < 1))
+		return(OKAY);
+	upsampleFactor = (int)cast_handle->upsampleRatio;
+	maxFrames = cast_handle->playbackBufAllocSize / (numChannels * upsampleFactor);
+
+	if ((cast_handle->playbackResampler != NULL) &&
+		((cast_handle->playbackResampler->getMaxChannels() < numChannels) ||
+		 (cast_handle->playbackResampler->getMaxFactor() < upsampleFactor) ||
+		 (cast_handle->playbackResampler->getMaxFrames() < maxFrames)))
+	{
+		delete cast_handle->playbackResampler;
+		cast_handle->playbackResampler = NULL;
+	}
+
+	if (cast_handle->playbackResampler == NULL)
+		cast_handle->playbackResampler = new (std::nothrow) Resampler(numChannels, upsampleFactor, maxFrames);
+
+	if (cast_handle->playbackResampler == NULL)
+		return(NOT_OKAY);
+
+	if (!cast_handle->playbackResampler->configure(upsampleFactor, numChannels))
+		return(NOT_OKAY);
+
+	cast_handle->playbackResampler->reset();
+
+	return(OKAY);
+}
 
 /*
  * FUNCTION: sndDevicesReInit()
@@ -308,6 +353,9 @@ int PT_DECLSPEC sndDevicesReInit(PT_HANDLE *hp_sndDevices, int i_initType, int *
 			cast_handle->playbackBufAllocSize = playbackAllocSize;
 
 			if ((cast_handle->fCaptureBuf == NULL) || (cast_handle->fPlaybackBuf == NULL) || (cast_handle->fFilePlaybackBuf == NULL))
+				return(NOT_OKAY);
+
+			if (sndDevices_SetupPlaybackResampler(hp_sndDevices) != OKAY)
 				return(NOT_OKAY);
 
 			// Do the final format dependent setup of capture and playback devices.

--- a/audiopassthru/src/sndDevices/sndDevicesSet.cpp
+++ b/audiopassthru/src/sndDevices/sndDevicesSet.cpp
@@ -444,10 +444,10 @@ int PT_DECLSPEC sndDevicesSetDeviceEnabledStatusFromGuid(PT_HANDLE *hp_sndDevice
 
 /*
  * FUNCTION: sndDevicesSetDfxDeviceSampleRateAndChannels()
- * DESCRIPTION: Sets the sample rate of the DFX device to either SND_DEVICES_DFX_SAMP_FREQ_44_1
- * or SND_DEVICES_DFX_SAMP_FREQ_48 and sets the num channels to specified setting.
+ * DESCRIPTION: Sets the sample rate of the DFX device to i_sampRate in Hz and sets the num channels to
+ * specified setting. Reports SND_DEVICES_DEVICE_SET_FORMAT_FAILED when the driver does not offer the rate.
  */
-int PT_DECLSPEC sndDevicesSetDfxDeviceSampleRateAndChannels(PT_HANDLE *hp_sndDevices, int i_sampRateFlag, int iNumChannels, int *ip_resultFlag)
+int PT_DECLSPEC sndDevicesSetDfxDeviceSampleRateAndChannels(PT_HANDLE *hp_sndDevices, int i_sampRate, int iNumChannels, int *ip_resultFlag)
 {
 	struct sndDevicesHdlType *cast_handle;
 	IPolicyConfigVista *pPolicyConfigVista;
@@ -470,6 +470,9 @@ int PT_DECLSPEC sndDevicesSetDfxDeviceSampleRateAndChannels(PT_HANDLE *hp_sndDev
 	if( (iNumChannels < SND_DEVICES_MIN_NUM_CHANS) || (iNumChannels > SND_DEVICES_MAX_NUM_CHANS) )
 		return(NOT_OKAY);
 
+	if( (i_sampRate < SND_DEVICES_MIN_SAMP_FREQ) || (i_sampRate > SND_DEVICES_MAX_SAMP_FREQ) )
+		return(NOT_OKAY);
+
 	/* Uses Vista version of IPolicyConfig, works on Vista and Win7 */
 	hr = CoCreateInstance(__uuidof(CPolicyConfigVistaClient), 
 		NULL, CLSCTX_ALL, __uuidof(IPolicyConfigVista), (LPVOID *)&pPolicyConfigVista);
@@ -487,10 +490,7 @@ int PT_DECLSPEC sndDevicesSetDfxDeviceSampleRateAndChannels(PT_HANDLE *hp_sndDev
 		SND_DEVICES_SET_STATUS_AND_RETURN_OK(SND_DEVICES_DEVICE_GET_FORMAT_FAILED);
 	}
 
-	if( i_sampRateFlag == SND_DEVICES_DFX_SAMP_FREQ_44_1 )
-		pwfx->Format.nSamplesPerSec = 44100;
-	else
-		pwfx->Format.nSamplesPerSec = 48000;
+	pwfx->Format.nSamplesPerSec = i_sampRate;
 
 	pwfx->Format.nChannels = iNumChannels;
 
@@ -507,17 +507,36 @@ int PT_DECLSPEC sndDevicesSetDfxDeviceSampleRateAndChannels(PT_HANDLE *hp_sndDev
 		pwfx->dwChannelMask = 1599;	// As in 5.1 case, channel mask has to be different than you would expect.
 
 	hr = pPolicyConfigVista->SetDeviceFormat(cast_handle->pwszID[cast_handle->dfxDeviceNum], pwfx, NULL);
+	CoTaskMemFree(pwfx);
+
+	// Older drivers reject higher rates, that is expected and not traced as an error.
+	if (hr == AUDCLNT_E_UNSUPPORTED_FORMAT)
+	{
+		*ip_resultFlag = SND_DEVICES_DEVICE_SET_FORMAT_FAILED;
+		pPolicyConfigVista->Release();
+		return(OKAY);
+	}
+
 	if (FAILED(hr))
 	{
 		*ip_resultFlag = SND_DEVICES_DEVICE_SET_FORMAT_FAILED;
-		CoTaskMemFree(pwfx);
 		pPolicyConfigVista->Release();
 		SND_DEVICES_SET_STATUS_AND_RETURN_OK(SND_DEVICES_DEVICE_SET_FORMAT_FAILED);
 	}
 
-	// pwfx was allocated by GetDeviceFormat() above; free it before returning.
-	CoTaskMemFree(pwfx);
+	// Read the format back, the policy call can succeed without the rate changing.
+	hr = pPolicyConfigVista->GetDeviceFormat(cast_handle->pwszID[cast_handle->dfxDeviceNum], FALSE, &pwfx);
+	if (FAILED(hr))
+	{
+		*ip_resultFlag = SND_DEVICES_DEVICE_GET_FORMAT_FAILED;
+		pPolicyConfigVista->Release();
+		SND_DEVICES_SET_STATUS_AND_RETURN_OK(SND_DEVICES_DEVICE_GET_FORMAT_FAILED);
+	}
 
+	if (pwfx->Format.nSamplesPerSec != (DWORD)i_sampRate)
+		*ip_resultFlag = SND_DEVICES_DEVICE_SET_FORMAT_FAILED;
+
+	CoTaskMemFree(pwfx);
 	pPolicyConfigVista->Release();
 
 	return(OKAY);

--- a/dsp/DfxDsp.vcxproj
+++ b/dsp/DfxDsp.vcxproj
@@ -227,6 +227,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\DfxDsp.h" />
+    <ClInclude Include="include\Resampler.h" />
     <ClInclude Include="ptComSftDfx\u_comSftwr.h" />
     <ClInclude Include="ptutil\COM\u_com.h" />
     <ClInclude Include="ptutil\dfxp\u_dfxp.h" />
@@ -345,6 +346,7 @@
     <ClCompile Include="ptutil\DspUtil\GraphicEq\GraphicEqInitSections.cpp" />
     <ClCompile Include="ptutil\DspUtil\GraphicEq\GraphicEqProcess.cpp" />
     <ClCompile Include="ptutil\DspUtil\GraphicEq\GraphicEqSet.cpp" />
+    <ClCompile Include="ptutil\DspUtil\Resampler\Resampler.cpp" />
     <ClCompile Include="ptutil\DspUtil\spectrum\spectrumGet.cpp" />
     <ClCompile Include="ptutil\DspUtil\spectrum\spectrumInit.cpp" />
     <ClCompile Include="ptutil\DspUtil\spectrum\spectrumMessageValues.cpp" />

--- a/dsp/DfxDsp.vcxproj.filters
+++ b/dsp/DfxDsp.vcxproj.filters
@@ -34,6 +34,9 @@
     <Filter Include="Source Files\ptutil\DspUtil\GraphicEq">
       <UniqueIdentifier>{a24b254b-eae9-49a3-86a7-c649d21cc951}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\ptutil\DspUtil\Resampler">
+      <UniqueIdentifier>{a428c37f-980e-420b-8a18-cfeb138f16a8}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Source Files\ptutil\Sos">
       <UniqueIdentifier>{a068e7c0-4eb7-4ddb-9a7a-a4243589c957}</UniqueIdentifier>
     </Filter>
@@ -282,6 +285,9 @@
     <ClInclude Include="include\DfxDsp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Resampler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DfxDsp.cpp">
@@ -379,6 +385,9 @@
     </ClCompile>
     <ClCompile Include="ptutil\DspUtil\GraphicEq\GraphicEqSet.cpp">
       <Filter>Source Files\ptutil\DspUtil\GraphicEq</Filter>
+    </ClCompile>
+    <ClCompile Include="ptutil\DspUtil\Resampler\Resampler.cpp">
+      <Filter>Source Files\ptutil\DspUtil\Resampler</Filter>
     </ClCompile>
     <ClCompile Include="ptutil\SOS\Sos.cpp">
       <Filter>Source Files\ptutil\Sos</Filter>

--- a/dsp/include/Resampler.h
+++ b/dsp/include/Resampler.h
@@ -1,0 +1,63 @@
+/*
+FxSound
+Copyright (C) 2025  FxSound LLC
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _RESAMPLER_H_
+#define _RESAMPLER_H_
+
+#include <vector>
+
+/*
+ * Integer factor polyphase FIR resampler for interleaved float audio, with
+ * separate histories for interpolation and decimation. All memory is
+ * allocated by the constructor, and input and output may be the same buffer.
+ */
+class Resampler
+{
+public:
+	Resampler(int channel_capacity, int factor_capacity, int frame_capacity);
+
+	bool configure(int new_factor, int new_channels);
+	void reset();
+
+	void interpolate(const float *input, int input_frames, float *output);
+	void decimate(const float *input, int input_frames, float *output);
+
+	int getFactor() const { return factor_; }
+	int getChannels() const { return channels_; }
+	int getMaxChannels() const { return max_channels_; }
+	int getMaxFactor() const { return max_factor_; }
+	int getMaxFrames() const { return max_frames_; }
+
+private:
+	void designKernel();
+	void loadChannel(const float *input, int ch, int frames, const float *history, int history_frames);
+
+	int max_channels_;
+	int max_factor_;
+	int max_frames_;
+	int factor_;
+	int channels_;
+	std::vector<double> prototype_;
+	std::vector<float> up_phases_;
+	std::vector<float> down_kernel_;
+	std::vector<float> up_history_;
+	std::vector<float> down_history_;
+	std::vector<float> work_;
+};
+
+#endif

--- a/dsp/ptutil/COM/Com.cpp
+++ b/dsp/ptutil/COM/Com.cpp
@@ -50,6 +50,8 @@ extern "C"
 
 #include "com.h"
 #include "u_com.h"
+#include <new>
+#include "Resampler.h"
 #include "mry.h"
 #include "dongle.h"
 
@@ -86,6 +88,13 @@ int PT_DECLSPEC comInit(PT_HANDLE **hpp_com, int i_softdsp, int i_board_address,
 	if (cast_handle == NULL)
 		return(NOT_OKAY);
     
+	cast_handle->resampler_hdl = new (std::nothrow) Resampler(COM_RESAMPLE_MAX_CHANNELS, COM_RESAMPLE_MAX_FACTOR, COM_RESAMPLE_MAX_FRAMES);
+	if (cast_handle->resampler_hdl == NULL)
+	{
+		free(cast_handle);
+		return(NOT_OKAY);
+	}
+
 	cast_handle->slout_hdl = hp_slout;
     /* Used to index software processor memory spaces and vars */
 	cast_handle->processor_index = i_processor_num - 1;
@@ -429,6 +438,8 @@ int PT_DECLSPEC comFreeUp(PT_HANDLE **hpp_com)
 
 	if( comSftwrFreeUp( &(cast_handle->comSftwr_hdl) ) != OKAY)
 		return(NOT_OKAY);
+
+	delete cast_handle->resampler_hdl;
 
 	free(cast_handle);
 

--- a/dsp/ptutil/COM/Comwave.cpp
+++ b/dsp/ptutil/COM/Comwave.cpp
@@ -50,6 +50,7 @@ extern "C"
 #include "pwav.h"
 #include "com.h"
 #include "u_com.h"
+#include "Resampler.h"
 
 /* FUNCTION: comProcessBuffer()
  * DESCRIPTION:
@@ -94,10 +95,10 @@ int PT_DECLSPEC comProcessWaveBuffer(PT_HANDLE *hp_com, long *lp_data, float *rp
    struct comHdlType *cast_handle;
 	long *l_ptr;
 	float *f_ptr;
-	int leftover_samples;
-	int num_down_sample_sets;
 	int num_sample_sets_to_process;
-	int i,j;
+	int num_channels;
+	int num_resample_frames;
+	int i, j;
 
    cast_handle = (struct comHdlType *)hp_com;
 
@@ -120,29 +121,22 @@ int PT_DECLSPEC comProcessWaveBuffer(PT_HANDLE *hp_com, long *lp_data, float *rp
    // since /sdl option is turned on in DfxDsp (it is turned off in original code base so this was treated as warning instead of error).
 	f_ptr = (float *)l_ptr;
    
-	// Downsample the data if needed for higher data sampling frequencies
+	num_channels = i_stereo_in_mode ? 2 : 1;
+	num_resample_frames = l_length;
+
+	// Filter signals above the DSP rate down for processing and back up afterwards.
 	if(i_down_sample_ratio > 1)
 	{
-		f_ptr = (float *)l_ptr;
-		leftover_samples = l_length % i_down_sample_ratio;
-		num_down_sample_sets = l_length/i_down_sample_ratio;
-		num_sample_sets_to_process = num_down_sample_sets;
+		if( (cast_handle->resampler_hdl == NULL) || (l_length > cast_handle->resampler_hdl->getMaxFrames()) ||
+			!cast_handle->resampler_hdl->configure(i_down_sample_ratio, num_channels) )
+			return(NOT_OKAY);
 
-		if(i_stereo_in_mode)
-		{
-			for(i=0; i<num_down_sample_sets; i++)
-			{
-				f_ptr[i * 2]     = f_ptr[i * 2 * i_down_sample_ratio];
-				f_ptr[i * 2 + 1] = f_ptr[i * 2 * i_down_sample_ratio + 1];
-			}
-		}
-		else // Mono case
-		{
-			for(i=0; i< num_down_sample_sets; i++)
-			{
-				f_ptr[i] = f_ptr[i * i_down_sample_ratio];
-			}
-		}
+		num_resample_frames = l_length - (l_length % i_down_sample_ratio);
+		if(num_resample_frames == 0)
+			return(OKAY);
+
+		cast_handle->resampler_hdl->decimate(f_ptr, num_resample_frames, f_ptr);
+		num_sample_sets_to_process = num_resample_frames / i_down_sample_ratio;
 	}
 
 	if (cast_handle->softdsp_mode)
@@ -162,45 +156,14 @@ int PT_DECLSPEC comProcessWaveBuffer(PT_HANDLE *hp_com, long *lp_data, float *rp
 		return(NOT_OKAY);
    }
 
-	// Upsample the data if needed for higher data sampling frequencies
 	if(i_down_sample_ratio > 1)
 	{
-		if(i_stereo_out_mode)
-		{
-			for(i=(num_down_sample_sets - 1); i >= 0; i--)
-			{
-				// To be replace with sample averaging operation
-				for(j=0; j<i_down_sample_ratio; j++)
-				{
-					f_ptr[i * 2 * i_down_sample_ratio + j * 2] = f_ptr[i * 2];
-					f_ptr[i * 2 * i_down_sample_ratio + 1 + j * 2] = f_ptr[i * 2 + 1];
-				}
-			}
-			if( leftover_samples > 0 ) // Fill in leftover samples with last processed value
-				for(i=0; i<leftover_samples; i++)
-				{
-					f_ptr[ (num_down_sample_sets * i_down_sample_ratio + i) * 2 ] = 
-							f_ptr[ (num_down_sample_sets * i_down_sample_ratio - 1) * 2 ];
+		cast_handle->resampler_hdl->interpolate(f_ptr, num_sample_sets_to_process, f_ptr);
 
-					f_ptr[ (num_down_sample_sets * i_down_sample_ratio + i) * 2 + 1 ] = 
-							f_ptr[ (num_down_sample_sets * i_down_sample_ratio - 1) * 2 + 1 ];
-				}
-		}
-		else // Mono case
-		{
-			for(i=(num_down_sample_sets - 1); i >= 0; i--)
-			{
-				for(j=0; j<i_down_sample_ratio; j++)
-					f_ptr[i * i_down_sample_ratio + j] = f_ptr[i];
-			}
-
-			if( leftover_samples > 0 ) // Fill in leftover samples with last processed value
-				for(i=0; i<leftover_samples; i++)
-				{
-					f_ptr[ num_down_sample_sets * i_down_sample_ratio + i] = 
-							f_ptr[ num_down_sample_sets * i_down_sample_ratio - 1];
-				}
-		}
+		// Leftover frames past the last whole block repeat the final resampled frame.
+		for(i = num_resample_frames; i < l_length; i++)
+			for(j = 0; j < num_channels; j++)
+				f_ptr[i * num_channels + j] = f_ptr[(num_resample_frames - 1) * num_channels + j];
 	}
 
 	if ( i_format_flag == COM_24_BIT_SAMPLES )

--- a/dsp/ptutil/COM/u_com.h
+++ b/dsp/ptutil/COM/u_com.h
@@ -27,6 +27,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int com_ReadSerialNum(PT_HANDLE *, int, unsigned long *);
 
 /* com handle definition */
+class Resampler;
+
 struct comHdlType {
 	CSlout *slout_hdl;
 	CSlout *debug_slout_hdl;
@@ -62,6 +64,7 @@ struct comHdlType {
 	long buffer_size; /* Size of buffers for WAV and DAW processing */
 	int softdsp_mode; /* 1 -> software DSP, 0 -> hardware DSP */
 	PT_HANDLE *comSftwr_hdl;
+	Resampler *resampler_hdl; /* Carries signals above the DSP rate down for processing and back up */
 };
 
 /* 

--- a/dsp/ptutil/DspUtil/Resampler/Resampler.cpp
+++ b/dsp/ptutil/DspUtil/Resampler/Resampler.cpp
@@ -1,0 +1,206 @@
+/*
+FxSound
+Copyright (C) 2025  FxSound LLC
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <math.h>
+#include <string.h>
+#include <algorithm>
+
+#include "Resampler.h"
+
+namespace
+{
+	constexpr int kTapsPerPhase = 128;
+	constexpr double kKaiserBeta = 8.96;
+	constexpr double kPassbandEdge = 0.907;
+	constexpr double kPi = 3.14159265358979323846;
+
+	double besselI0(double x)
+	{
+		double sum = 1.0;
+		double term = 1.0;
+
+		for (int k = 1; term > 1e-12 * sum; k++)
+		{
+			double ratio = x / (2.0 * k);
+			term *= ratio * ratio;
+			sum += term;
+		}
+
+		return sum;
+	}
+
+	float dotProduct(const float *coeffs, const float *samples, int count)
+	{
+		float acc0 = 0.0f;
+		float acc1 = 0.0f;
+		float acc2 = 0.0f;
+		float acc3 = 0.0f;
+
+		for (int i = 0; i < count; i += 4)
+		{
+			acc0 += coeffs[i] * samples[i];
+			acc1 += coeffs[i + 1] * samples[i + 1];
+			acc2 += coeffs[i + 2] * samples[i + 2];
+			acc3 += coeffs[i + 3] * samples[i + 3];
+		}
+
+		return (acc0 + acc1) + (acc2 + acc3);
+	}
+}
+
+Resampler::Resampler(int channel_capacity, int factor_capacity, int frame_capacity)
+	: max_channels_(channel_capacity), max_factor_(factor_capacity), max_frames_(frame_capacity), factor_(1), channels_(1)
+{
+	int max_taps = max_factor_ * kTapsPerPhase;
+
+	prototype_.resize(max_taps);
+	up_phases_.resize(max_taps);
+	down_kernel_.resize(max_taps);
+	up_history_.resize((kTapsPerPhase - 1) * max_channels_);
+	down_history_.resize((max_taps - 1) * max_channels_);
+	work_.resize(max_taps - 1 + max_frames_);
+}
+
+bool Resampler::configure(int new_factor, int new_channels)
+{
+	if ((new_factor < 1) || (new_factor > max_factor_) || (new_channels < 1) || (new_channels > max_channels_))
+		return false;
+
+	if ((new_factor == factor_) && (new_channels == channels_))
+		return true;
+
+	factor_ = new_factor;
+	channels_ = new_channels;
+	designKernel();
+	reset();
+
+	return true;
+}
+
+void Resampler::reset()
+{
+	std::fill(up_history_.begin(), up_history_.end(), 0.0f);
+	std::fill(down_history_.begin(), down_history_.end(), 0.0f);
+}
+
+/*
+ * Kaiser windowed sinc lowpass at the lower Nyquist, expressed at the higher
+ * rate. With the cutoff mid transition the passband is flat to 90.7% of the
+ * lower Nyquist and the stopband starts at Nyquist, about 90 dB down.
+ */
+void Resampler::designKernel()
+{
+	int taps = factor_ * kTapsPerPhase;
+	double center = (taps - 1) / 2.0;
+	double cutoff = (kPassbandEdge + 1.0) * 0.25 / factor_;
+	double window_norm = besselI0(kKaiserBeta);
+	double sum = 0.0;
+
+	for (int n = 0; n < taps; n++)
+	{
+		double t = n - center;
+		double sinc = (t == 0.0) ? 2.0 * cutoff : sin(2.0 * kPi * cutoff * t) / (kPi * t);
+		double r = 2.0 * t / (taps - 1);
+		double window = besselI0(kKaiserBeta * sqrt(1.0 - r * r)) / window_norm;
+
+		prototype_[n] = sinc * window;
+		sum += prototype_[n];
+	}
+
+	for (int n = 0; n < taps; n++)
+		prototype_[n] /= sum;
+
+	for (int q = 0; q < taps; q++)
+		down_kernel_[q] = (float)prototype_[taps - 1 - q];
+
+	for (int phase = 0; phase < factor_; phase++)
+		for (int q = 0; q < kTapsPerPhase; q++)
+			up_phases_[phase * kTapsPerPhase + q] = (float)(factor_ * prototype_[(kTapsPerPhase - 1 - q) * factor_ + phase]);
+}
+
+/*
+ * Lays one channel out in work_ as [history][new samples], so every input
+ * sample is read before any output is written and in-place calls are safe.
+ */
+void Resampler::loadChannel(const float *input, int ch, int frames, const float *history, int history_frames)
+{
+	memcpy(work_.data(), history, history_frames * sizeof(float));
+
+	for (int i = 0; i < frames; i++)
+		work_[history_frames + i] = input[i * channels_ + ch];
+}
+
+void Resampler::interpolate(const float *input, int input_frames, float *output)
+{
+	if (input_frames > max_frames_)
+		input_frames = max_frames_;
+
+	if (factor_ == 1)
+	{
+		if (input != output)
+			memcpy(output, input, input_frames * channels_ * sizeof(float));
+		return;
+	}
+
+	int history_frames = kTapsPerPhase - 1;
+
+	for (int ch = 0; ch < channels_; ch++)
+	{
+		float *history = &up_history_[ch * history_frames];
+
+		loadChannel(input, ch, input_frames, history, history_frames);
+		memcpy(history, &work_[input_frames], history_frames * sizeof(float));
+
+		for (int i = 0; i < input_frames; i++)
+		{
+			const float *samples = &work_[i];
+
+			for (int phase = 0; phase < factor_; phase++)
+				output[(i * factor_ + phase) * channels_ + ch] = dotProduct(&up_phases_[phase * kTapsPerPhase], samples, kTapsPerPhase);
+		}
+	}
+}
+
+void Resampler::decimate(const float *input, int input_frames, float *output)
+{
+	if (input_frames > max_frames_)
+		input_frames = max_frames_;
+
+	if (factor_ == 1)
+	{
+		if (input != output)
+			memcpy(output, input, input_frames * channels_ * sizeof(float));
+		return;
+	}
+
+	int taps = factor_ * kTapsPerPhase;
+	int history_frames = taps - 1;
+	int output_frames = input_frames / factor_;
+	int used_frames = output_frames * factor_;
+
+	for (int ch = 0; ch < channels_; ch++)
+	{
+		float *history = &down_history_[ch * history_frames];
+
+		loadChannel(input, ch, used_frames, history, history_frames);
+		memcpy(history, &work_[used_frames], history_frames * sizeof(float));
+
+		for (int j = 0; j < output_frames; j++)
+			output[j * channels_ + ch] = dotProduct(down_kernel_.data(), &work_[j * factor_], taps);
+	}
+}

--- a/dsp/ptutil/dfxp/dfxpProcessReal.cpp
+++ b/dsp/ptutil/dfxp/dfxpProcessReal.cpp
@@ -37,6 +37,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "BinauralSyn.h"
 #include "GraphicEq.h"
 
+#if DAW_MAX_BUFFER_SIZE > COM_RESAMPLE_MAX_FRAMES
+#error COM_RESAMPLE_MAX_FRAMES must hold a full DAW_MAX_BUFFER_SIZE processing buffer
+#endif
+
 extern "C" {
 #include "comSftwr.h"
 }

--- a/dsp/ptutil/include/com.h
+++ b/dsp/ptutil/include/com.h
@@ -111,6 +111,11 @@ int PT_DECLSPEC comSetDemoMode(PT_HANDLE *, int);
 int PT_DECLSPEC comEepromUnsignedLongRead(PT_HANDLE *, short unsigned, unsigned long *);
 int PT_DECLSPEC comEepromUnsignedLongWrite(PT_HANDLE *, short unsigned, unsigned long);
 
+/* Resampler capacity, the frame count matches DAW_MAX_BUFFER_SIZE in u_dfxp.h */
+#define COM_RESAMPLE_MAX_CHANNELS 2
+#define COM_RESAMPLE_MAX_FACTOR 4
+#define COM_RESAMPLE_MAX_FRAMES 16384L
+
 /* comWave.cpp */
 int PT_DECLSPEC comProcessWaveBuffer(PT_HANDLE *, long *, realtype *, long, int, int, int, int);
 int PT_DECLSPEC comProcessBuffer(PT_HANDLE *hp_com, long *lp_data, long l_length, 


### PR DESCRIPTION
## Summary

FxSound pins its virtual device to 44.1 or 48 kHz and, when the output device runs faster, fills the gap by repeating each frame (`sndDevicesDoPlayback.cpp`). With a 96 or 192 kHz output that costs about 2.6 dB at 20 kHz and leaves images above 24 kHz in the signal. Inside the DSP, rates above 48 kHz were handled the same way: every Nth sample was kept and the result repeated afterwards (`Comwave.cpp`), which aliases anything above the internal Nyquist.

This makes high output rates work properly:

- **The FxSound Audio Enhancer device follows the output device rate.** `sndDevicesImplementDeviceRules` now asks for the playback rate first. A driver that only offers 44.1/48 kHz answers `AUDCLNT_E_UNSUPPORTED_FORMAT`, in which case the rate from the same family is used exactly as before, so nothing changes for existing installs. The matching driver change is https://github.com/fxsound2/fxsound-driver/pull/8.
- **A polyphase FIR resampler replaces sample repetition in both places.** `Resampler` (`dsp/include/Resampler.h`) is a Kaiser windowed sinc design with 128 taps per phase, flat to 90.7 % of the lower Nyquist and about 90 dB down in the stopband. It allocates only in its constructor and processes interleaved buffers in place, so nothing allocates on the processing thread.
  - `sndDevicesDoPlayback` interpolates with it while the device is still slower than the output (current driver).
  - `comProcessWaveBuffer` decimates with it before the effects chain and interpolates afterwards for 88.2 kHz and above. The equalizer already runs at the full rate and is untouched.

With the updated driver the whole chain runs at the output rate: capture at 192 kHz, EQ at 192 kHz, effects at 48 kHz through the FIR pair, playback at 192 kHz with no resampling in the passthru.

## Behaviour by configuration

| Driver | Output device | Before | After |
|---|---|---|---|
| current (max 48 kHz) | 44.1 / 48 kHz | unchanged | unchanged |
| current (max 48 kHz) | 88.2 / 96 / 176.4 / 192 kHz | frame repeat, -2.6 dB at 20 kHz, images | FIR interpolation, flat, images below -110 dB |
| updated | 88.2 / 96 / 176.4 / 192 kHz | n/a | device runs at the output rate, EQ at full rate, no passthru resampling |

## Testing

- `Resampler` unit test (x4 and x2, 1 to 8 channels): chunked processing with random block sizes is bit-identical to a single call, in-place equals out-of-place, 8-channel interleaved equals per-channel mono. Spectral check with numpy: images after x4 interpolation at -114 dB or lower, aliases after x4 decimation at -111 dB or lower, passband gain +0.0002 dB at 20 kHz, round-trip delay 0.66 ms at 192 kHz.
- `IPolicyConfig::SetDeviceFormat` with 88.2, 96 and 192 kHz against the shipped driver returns `AUDCLNT_E_UNSUPPORTED_FORMAT` and leaves the endpoint format untouched, so the fallback path is what every current install takes.
- `audiopassthru` and `DfxDsp` build for x64 and Win32 Release with no new warnings.

Not covered: the binaural stage still skips rates above 48 kHz (existing `PTNOTE` in `dfxpProcessReal.cpp`), and the decimated path treats the in and out stereo modes as equal, which is how every caller uses it.

Related: #209, #475, #92.
